### PR TITLE
Support for GT2.2

### DIFF
--- a/include/ghex/glue/gridtools/field.hpp
+++ b/include/ghex/glue/gridtools/field.hpp
@@ -10,12 +10,13 @@
  */
 #pragma once
 
+#include <type_traits>
+
 #include <ghex/config.hpp>
 #include <ghex/arch_traits.hpp>
 #include <ghex/structured/regular/field_descriptor.hpp>
 #include <ghex/glue/gridtools/processor_grid.hpp>
 #include <gridtools/storage/data_store.hpp>
-#include <gridtools/meta/type_traits.hpp>
 #include <gridtools/meta/list_to_iseq.hpp>
 
 namespace ghex
@@ -29,7 +30,7 @@ namespace _impl
 //}
 
 template <class Int>
-using not_negative = gridtools::bool_constant<(Int::value >= 0)>;
+using not_negative = std::integral_constant<bool, (Int::value >= 0)>;
 
 template<typename Seq>
 struct get_layout_map;


### PR DESCRIPTION
GridTools 2.2 removes `gridtools/meta/type_traits.hpp`, as this was providing ports to C++14 for some traits introduced to the STL with C++17 (which is a requirement for GridTools version ≥ 2.2). With this PR, GHEX supports both GridTools versions < 2.2 with C++14 (or C++17) and GridTools versions ≥ 2.2 with C++17.