### PR TITLE
unstructured level strides

### DIFF
--- a/benchmarks/unstructured_parmetis.cpp
+++ b/benchmarks/unstructured_parmetis.cpp
@@ -681,7 +681,7 @@ TEST(unstructured_parmetis, receive_type) {
     initialize_field(d, f_cpu, d_id_offset);
     idx_t* f_gpu = gpu_alloc.allocate(d.size() * d.levels());
     GHEX_CHECK_CUDA_RESULT(cudaMemcpy(f_gpu, f_cpu.data(), d.size() * d.levels() * sizeof(idx_t), cudaMemcpyHostToDevice));
-    data_descriptor_gpu_type<idx_t> data_gpu{d, f_gpu, device_id};
+    data_descriptor_gpu_type<idx_t> data_gpu{d, f_gpu, 1, true, device_id};
 
     // exchange
     for (int i = 0; i < n_iters_warm_up; ++i) { // warm-up
@@ -719,7 +719,7 @@ TEST(unstructured_parmetis, receive_type) {
     initialize_field(d_ord, f_ord_cpu, d_id_offset);
     idx_t* f_ord_gpu = gpu_alloc.allocate(d_ord.size() * d_ord.levels());
     GHEX_CHECK_CUDA_RESULT(cudaMemcpy(f_ord_gpu, f_ord_cpu.data(), d_ord.size() * d_ord.levels() * sizeof(idx_t), cudaMemcpyHostToDevice));
-    data_descriptor_gpu_type<idx_t> data_ord_gpu{d_ord, f_ord_gpu, device_id};
+    data_descriptor_gpu_type<idx_t> data_ord_gpu{d_ord, f_ord_gpu, 1, true, device_id};
 
     // exchange
     for (int i = 0; i < n_iters_warm_up; ++i) { // warm-up
@@ -754,7 +754,7 @@ TEST(unstructured_parmetis, receive_type) {
     initialize_field(d_ord, f_ipr_cpu, d_id_offset);
     idx_t* f_ipr_gpu = gpu_alloc.allocate(d_ord.size() * d_ord.levels());
     GHEX_CHECK_CUDA_RESULT(cudaMemcpy(f_ipr_gpu, f_ipr_cpu.data(), d_ord.size() * d_ord.levels() * sizeof(idx_t), cudaMemcpyHostToDevice));
-    data_descriptor_gpu_type<idx_t> data_ipr_gpu{d_ord, f_ipr_gpu, device_id};
+    data_descriptor_gpu_type<idx_t> data_ipr_gpu{d_ord, f_ipr_gpu, 1, true, device_id};
 
     // exchange
     for (int i = 0; i < n_iters_warm_up; ++i) { // warm-up

--- a/include/ghex/unstructured/user_concepts.hpp
+++ b/include/ghex/unstructured/user_concepts.hpp
@@ -456,7 +456,7 @@ class data_descriptor<ghex::cpu, DomainId, Idx, T>
 template<typename T>
 __global__ void
 pack_kernel(const T* values, const std::size_t local_indices_size,
-    const std::size_t* local_indices, const std::size_t levels, T* buffer
+    const std::size_t* local_indices, const std::size_t levels, T* buffer,
     const std::size_t m_index_stride, const std::size_t m_level_stride,
     const std::size_t buffer_index_stride, const std::size_t buffer_level_stride)
 {

--- a/include/ghex/unstructured/user_concepts.hpp
+++ b/include/ghex/unstructured/user_concepts.hpp
@@ -457,7 +457,7 @@ template<typename T>
 __global__ void
 pack_kernel(const T* values, const std::size_t local_indices_size,
     const std::size_t* local_indices, const std::size_t levels, T* buffer,
-    const std::size_t m_index_stride, const std::size_t m_level_stride,
+    const std::size_t index_stride, const std::size_t level_stride,
     const std::size_t buffer_index_stride, const std::size_t buffer_level_stride)
 {
     const std::size_t idx = threadIdx.x + (blockIdx.x * blockDim.x);
@@ -474,7 +474,7 @@ template<typename T>
 __global__ void
 unpack_kernel(const T* buffer, const std::size_t local_indices_size,
     const std::size_t* local_indices, const std::size_t levels, T* values,
-    const std::size_t m_index_stride, const std::size_t m_level_stride,
+    const std::size_t index_stride, const std::size_t level_stride,
     const std::size_t buffer_index_stride, const std::size_t buffer_level_stride)
 {
     const std::size_t idx = threadIdx.x + (blockIdx.x * blockDim.x);

--- a/include/ghex/unstructured/user_concepts.hpp
+++ b/include/ghex/unstructured/user_concepts.hpp
@@ -551,7 +551,7 @@ class data_descriptor<gpu, DomainId, Idx, T>
                 static_cast<int>(std::ceil(static_cast<double>(is.local_indices().size()) /
                                            GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK));
             const std::size_t buffer_index_stride = m_levels_first ? m_levels : 1u;
-            const std::size_t buffer_level_stride = m_levels_first ? 1u : is.local_indices.size();
+            const std::size_t buffer_level_stride = m_levels_first ? 1u : is.local_indices().size();
             pack_kernel<value_type><<<n_blocks, GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK,
                 0, *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(m_values,
                 is.local_indices().size(), is.local_indices().data(), m_levels, buffer,
@@ -568,7 +568,7 @@ class data_descriptor<gpu, DomainId, Idx, T>
                 static_cast<int>(std::ceil(static_cast<double>(is.local_indices().size()) /
                                            GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK));
             const std::size_t buffer_index_stride = m_levels_first ? m_levels : 1u;
-            const std::size_t buffer_level_stride = m_levels_first ? 1u : is.local_indices.size();
+            const std::size_t buffer_level_stride = m_levels_first ? 1u : is.local_indices().size();
             unpack_kernel<value_type><<<n_blocks, GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK,
                 0, *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(buffer,
                 is.local_indices().size(), is.local_indices().data(), m_levels, m_values,

--- a/test/unstructured/test_user_concepts.cpp
+++ b/test/unstructured/test_user_concepts.cpp
@@ -35,7 +35,7 @@ void test_pattern_setup(ghex::context& ctxt);
 void test_pattern_setup_oversubscribe(ghex::context& ctxt);
 void test_pattern_setup_oversubscribe_asymm(ghex::context& ctxt);
 
-void test_data_descriptor(ghex::context& ctxt);
+void test_data_descriptor(ghex::context& ctxt, std::size_t levels, bool levels_first);
 void test_data_descriptor_oversubscribe(ghex::context& ctxt);
 void test_data_descriptor_threads(ghex::context& ctxt);
 
@@ -67,7 +67,13 @@ TEST_F(mpi_test_fixture, data_descriptor)
 {
     ghex::context ctxt{MPI_COMM_WORLD, thread_safe};
 
-    if (world_size == 4) { test_data_descriptor(ctxt); }
+    if (world_size == 4)
+    {
+        test_data_descriptor(ctxt, 1, true);
+        test_data_descriptor(ctxt, 3, true);
+        test_data_descriptor(ctxt, 1, false);
+        test_data_descriptor(ctxt, 3, false);
+    }
     else if (world_size == 2)
     {
         test_data_descriptor_oversubscribe(ctxt);
@@ -249,7 +255,7 @@ test_pattern_setup_oversubscribe_asymm(ghex::context& ctxt)
 
 /** @brief Test data descriptor concept*/
 void
-test_data_descriptor(ghex::context& ctxt)
+test_data_descriptor(ghex::context& ctxt, std::size_t levels, bool levels_first)
 {
     // domain
     std::vector<domain_descriptor_type> local_domains{make_domain(ctxt.rank())};
@@ -265,10 +271,10 @@ test_data_descriptor(ghex::context& ctxt)
     auto co = ghex::make_communication_object<pattern_container_type>(ctxt);
 
     // application data
-    auto&                         d = local_domains[0];
-    ghex::test::util::memory<int> field(d.size(), 0);
-    initialize_data(d, field);
-    data_descriptor_cpu_int_type data{d, field};
+    auto& d = local_domains[0];
+    ghex::test::util::memory<int> field(d.size()*levels, 0);
+    initialize_data(d, field, levels, levels_first);
+    data_descriptor_cpu_int_type data{d, field, levels, levels_first};
 
     EXPECT_NO_THROW(co.exchange(patterns(data)).wait());
 
@@ -276,13 +282,13 @@ test_data_descriptor(ghex::context& ctxt)
     h.wait();
 
     // check exchanged data
-    check_exchanged_data(d, field, patterns[0]);
+    check_exchanged_data(d, field, patterns[0], levels, levels_first);
 
 #ifdef GHEX_CUDACC
     // application data
-    initialize_data(d, field);
+    initialize_data(d, field, levels, levels_first);
     field.clone_to_device();
-    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), 1, true, 0};
+    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), levels, levels_first, 0};
 
     EXPECT_NO_THROW(co.exchange(patterns(data_gpu)).wait());
 
@@ -291,7 +297,7 @@ test_data_descriptor(ghex::context& ctxt)
 
     // check exchanged data
     field.clone_to_host();
-    check_exchanged_data(d, field, patterns[0]);
+    check_exchanged_data(d, field, patterns[0], levels, levels_first);
 #endif
 }
 

--- a/test/unstructured/test_user_concepts.cpp
+++ b/test/unstructured/test_user_concepts.cpp
@@ -282,7 +282,7 @@ test_data_descriptor(ghex::context& ctxt)
     // application data
     initialize_data(d, field);
     field.clone_to_device();
-    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), 0};
+    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), 1, true, 0};
 
     EXPECT_NO_THROW(co.exchange(patterns(data_gpu)).wait());
 
@@ -407,7 +407,7 @@ test_in_place_receive(ghex::context& ctxt)
     // application data
     initialize_data(d, field);
     field.clone_to_device();
-    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), 0};
+    data_descriptor_gpu_int_type data_gpu{d, field.device_data(), 1, true, 0};
 
     // communication object
     auto co_gpu = ghex::unstructured::make_communication_object_ipr(ctxt, patterns(data_gpu));


### PR DESCRIPTION
- levels are no longer assumed to be contiguous in memory
- python bindings compute strides from buffer_info object