### PR TITLE
python bindings for structured grids: improved make_communication_object function

### DIFF
--- a/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
@@ -27,20 +27,20 @@ namespace regular
 void
 register_communication_object(pybind11::module& m)
 {
+    auto _communication_object = register_class<communication_object_shim>(m);
+
     gridtools::for_each<
         gridtools::meta::transform<gridtools::meta::list, communication_object_specializations>>(
-        [&m](auto l)
+        [&m, &_communication_object](auto l)
         {
             using namespace std::string_literals;
             using namespace pybind11::literals;
             using communication_object_type = gridtools::meta::first<decltype(l)>;
             using handle_type = typename communication_object_type::handle_type;
             using pattern_type = typename communication_object_type::pattern_type;
-            using pattern_container_type = typename communication_object_type::pattern_container_type;
             using dimension = typename communication_object_type::grid_type::dimension;
             using fields = field_descriptor_specializations_<dimension::value>;
 
-            auto _communication_object = register_class<communication_object_type>(m);
             auto _handle = register_class<handle_type>(m);
 
             _handle
@@ -58,36 +58,32 @@ register_communication_object(pybind11::module& m)
                     _communication_object
                         .def(
                             "exchange",
-                            [](communication_object_type& co, std::vector<buffer_info_type> b)
+                            [](communication_object_shim& co, std::vector<buffer_info_type> b)
                             { return co.exchange(b.begin(), b.end()); },
                             pybind11::keep_alive<0, 1>())
                         .def(
                             "exchange",
-                            [](communication_object_type& co, buffer_info_type& b)
+                            [](communication_object_shim& co, buffer_info_type& b)
                             { return co.exchange(b); },
                             pybind11::keep_alive<0, 1>())
                         .def(
                             "exchange",
-                            [](communication_object_type& co, buffer_info_type& b0, buffer_info_type& b1)
+                            [](communication_object_shim& co, buffer_info_type& b0, buffer_info_type& b1)
                             { return co.exchange(b0, b1); },
                             pybind11::keep_alive<0, 1>())
                         .def(
                             "exchange",
-                            [](communication_object_type& co, buffer_info_type& b0, buffer_info_type& b1, buffer_info_type& b2)
+                            [](communication_object_shim& co, buffer_info_type& b0, buffer_info_type& b1, buffer_info_type& b2)
                             { return co.exchange(b0, b1, b2); },
                             pybind11::keep_alive<0, 1>());
                 });
-
-
-            m.def(
-                "make_co_regular",
-                [](context_shim& c, pattern_container_type&)
-                {
-                    auto co = ghex::make_communication_object<pattern_container_type>(c.m);
-                    return co;
-                },
-                pybind11::keep_alive<0, 1>());
         });
+
+        m.def(
+            "make_co_regular",
+            [](context_shim& c){ return communication_object_shim{&c.m, std::monostate{}}; },
+            pybind11::keep_alive<0, 1>());
+
 }
 
 } //namespace regular

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
@@ -11,6 +11,12 @@
 #include <ghex/communication_object.hpp>
 #include <structured/types.hpp>
 
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
 namespace pyghex
 {
 namespace structured
@@ -27,6 +33,93 @@ using communication_object_specializations =
     gridtools::meta::transform<gridtools::meta::rename<ghex::communication_object>::template apply,
         communication_object_args>;
 } // namespace
+
+
+// Communication object specializations are stored in a variant and constructed on demand before the first exchange.
+// - this removes the need to inject the pattern type at construction, i.e.
+//   in the python code `make_communication_object` takes only the context as argument instead of one
+//   of the pattern objects which was confusing
+// - if this communication object shim is later used with a different *type* of pattern, for example
+//   a 2d pattern instead of a 3d pattern, the exchange will fail with an exception
+struct communication_object_shim {
+    // the variant's first alternative is of type std::monostate to indicate the empty state
+    using variant_t =
+        gridtools::meta::rename<std::variant,
+            gridtools::meta::push_front<communication_object_specializations, std::monostate>>;
+    ghex::context* ctx = nullptr;
+    variant_t m;
+
+    // exchange of buffer info objects
+    template<typename... Patterns, typename... Archs, typename... Fields>
+    auto exchange(ghex::buffer_info<Patterns, Archs, Fields>&... b) {
+        return get_co<gridtools::meta::list<Patterns...>>().exchange(b...);
+    }
+
+    // exchange of iterator pairs pointing to buffer info ranges
+    template<typename... Its>
+    auto exchange(Its... its) {
+        // need even number of iterators (begin and end)
+        static_assert(sizeof...(Its) % 2 == 0);
+        return exchange_from_iterators(std::make_tuple(std::move(its)...), std::make_index_sequence<sizeof...(Its)/2>());
+    }
+
+  private:
+    // extractors for nested typedefs
+    template<typename It>
+    using get_pattern_t = typename std::iterator_traits<It>::value_type::pattern_type;
+    template<typename P>
+    using get_grid = typename P::grid_type;
+    template<typename P>
+    using get_did = typename P::domain_id_type;
+
+    template<typename... Its, std::size_t... Is>
+    auto exchange_from_iterators(std::tuple<Its...> t, std::index_sequence<Is...>) {
+        using begins = decltype(std::make_tuple(std::get<Is>(t)...));
+        using ends = decltype(std::make_tuple(std::get<Is+1>(t)...));
+        static_assert( std::is_same_v<begins, ends> );
+        static constexpr std::size_t half_size = sizeof...(Is);
+        return get_co<gridtools::meta::transform<get_pattern_t, begins>>().exchange(
+            std::get<Is>(t)..., std::get<Is + half_size>(t)...
+        );
+    }
+
+    // get the required communcation object specialization from the variant based on a list of pattern types
+    // - will initialize the communication object if the variant is empty
+    // - will throw if a different communication object specialization was initialized earlier
+    template<typename PatternList>
+    auto& get_co() {
+        // extract and deduplicate grids from patterns
+        using grids = gridtools::meta::dedup<
+            gridtools::meta::transform<
+                get_grid,
+                PatternList>>;
+        // check that all grids are of same type
+        static_assert(gridtools::meta::length<grids>::value == 1);
+
+        // extract and deduplicate domain ids from patterns
+        using dids = gridtools::meta::dedup<
+            gridtools::meta::transform<
+                get_did,
+                PatternList>>;
+        // check that all domain ids are of the same type
+        static_assert(gridtools::meta::length<dids>::value == 1);
+
+        // communication object type
+        using co_t = ghex::communication_object<gridtools::meta::at_c<grids, 0>, gridtools::meta::at_c<dids, 0>>;
+
+        // check whether co_t is in variant
+        static_assert(
+            gridtools::meta::find<communication_object_specializations, co_t>::value <
+            gridtools::meta::length<communication_object_specializations>::value);
+
+        // initialize variant with communication object if necessary
+        if (m.index() == 0) m.emplace<co_t>(*ctx);
+
+        // return the communication object
+        // throws if variant does not hold an alternative of type co_t
+        return std::get<co_t>(m);
+    }
+};
 
 } //namespace regular
 } // namespace structured

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
@@ -37,8 +37,7 @@ using communication_object_specializations =
 
 // Communication object specializations are stored in a variant and constructed on demand before the first exchange.
 // - this removes the need to inject the pattern type at construction, i.e.
-//   in the python code `make_communication_object` takes only the context as argument instead of one
-//   of the pattern objects which was confusing
+//   in the python function `make_communication_object` doesn't require a pattern object to infer the type anymore
 // - if this communication object shim is later used with a different *type* of pattern, for example
 //   a 2d pattern instead of a 3d pattern, the exchange will fail with an exception
 struct communication_object_shim {
@@ -75,7 +74,8 @@ struct communication_object_shim {
     // helper function for iterators
     template<typename... Its, std::size_t... Is>
     auto exchange_from_iterators(std::tuple<Its...> t, std::index_sequence<Is...>) {
-        using begins = decltype(std::make_tuple(std::get<Is>(t)...));
+        // every second iterator is a begin
+        using begins = decltype(std::make_tuple(std::get<Is*2>(t)...));
         static constexpr std::size_t half_size = sizeof...(Is);
         return get_co<gridtools::meta::transform<get_pattern_t, begins>>().exchange(
             std::get<Is>(t)..., std::get<Is + half_size>(t)...);

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
@@ -72,15 +72,13 @@ struct communication_object_shim {
     template<typename P>
     using get_did = typename P::domain_id_type;
 
+    // helper function for iterators
     template<typename... Its, std::size_t... Is>
     auto exchange_from_iterators(std::tuple<Its...> t, std::index_sequence<Is...>) {
         using begins = decltype(std::make_tuple(std::get<Is>(t)...));
-        using ends = decltype(std::make_tuple(std::get<Is+1>(t)...));
-        static_assert( std::is_same_v<begins, ends> );
         static constexpr std::size_t half_size = sizeof...(Is);
         return get_co<gridtools::meta::transform<get_pattern_t, begins>>().exchange(
-            std::get<Is>(t)..., std::get<Is + half_size>(t)...
-        );
+            std::get<Is>(t)..., std::get<Is + half_size>(t)...);
     }
 
     // get the required communcation object specialization from the variant based on a list of pattern types
@@ -89,18 +87,12 @@ struct communication_object_shim {
     template<typename PatternList>
     auto& get_co() {
         // extract and deduplicate grids from patterns
-        using grids = gridtools::meta::dedup<
-            gridtools::meta::transform<
-                get_grid,
-                PatternList>>;
+        using grids = gridtools::meta::dedup<gridtools::meta::transform<get_grid, PatternList>>;
         // check that all grids are of same type
         static_assert(gridtools::meta::length<grids>::value == 1);
 
         // extract and deduplicate domain ids from patterns
-        using dids = gridtools::meta::dedup<
-            gridtools::meta::transform<
-                get_did,
-                PatternList>>;
+        using dids = gridtools::meta::dedup<gridtools::meta::transform<get_did, PatternList>>;
         // check that all domain ids are of the same type
         static_assert(gridtools::meta::length<dids>::value == 1);
 
@@ -108,8 +100,7 @@ struct communication_object_shim {
         using co_t = ghex::communication_object<gridtools::meta::at_c<grids, 0>, gridtools::meta::at_c<dids, 0>>;
 
         // check whether co_t is in variant
-        static_assert(
-            gridtools::meta::find<communication_object_specializations, co_t>::value <
+        static_assert(gridtools::meta::find<communication_object_specializations, co_t>::value <
             gridtools::meta::length<communication_object_specializations>::value);
 
         // initialize variant with communication object if necessary

--- a/bindings/python/src/ghex/structured/regular.py
+++ b/bindings/python/src/ghex/structured/regular.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
     from ghex.context import context
 
 
-def make_communication_object(context: context, pattern):
-    return _make_co_regular(context, pattern)
+def make_communication_object(context: context):
+    return _make_co_regular(context)
 
 
 class DomainDescriptor(CppWrapper):

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -53,7 +53,7 @@ def test_pattern(capsys, mpi_cart_comm):
         print(pattern.grid_type)
         print(pattern.domain_id_type)
 
-    co = make_communication_object(ctx, pattern)
+    co = make_communication_object(ctx)
 
     def make_field():
         field_1 = np.zeros(


### PR DESCRIPTION
The communication object is wrapped in a type-erased shim class (structured case). Therefore, the `make_communication_object` function doesn't need the superfluous second argument anymore (this argument was only needed to inject the type and was confusing to use).
Type injection happens at exchange time now, and subsequently, the `communication_object` template instance is retrieved from a `std::variant`.