### PR TITLE
set `arch = None` default im `make_field_descriptor`

### DIFF
--- a/bindings/python/src/ghex/unstructured.py
+++ b/bindings/python/src/ghex/unstructured.py
@@ -36,7 +36,7 @@ def make_field_descriptor(
     domain_desc: DomainDescriptor,
     field: NDArray,
     *,
-    arch: Optional[Architecture] = Architecture.CPU,
+    arch: Optional[Architecture] = None,
 ) -> Any:
     if not arch:
         if hasattr(field, "__cuda_array_interface__") or hasattr(field, "__hip_array_interface__"):


### PR DESCRIPTION
Setting `arch = None` as default in `make_field_descriptor`: 

With the `default=Architecture.CPU` the caller needs to explicity call `make_field_descriptor` with `None` in order to take advantage of GHEX determining the architecture base on the field.`__x__array_interface__` attribute. This is easy to miss. 
