### PR TITLE
Unpin scikit-build-core

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,8 +4,7 @@ requires = [
     'cmake',
     'mpi4py>=3.1',
     'pybind11>=2.6',
-    #'scikit-build-core',
-    'scikit-build-core@git+https://github.com/scikit-build/scikit-build-core#egg=37ba268d04ab0816816bb8c7b0b1bc3388f91308',
+    'scikit-build-core',
     'wheel',
 ]
 


### PR DESCRIPTION
Since https://github.com/scikit-build/scikit-build-core/pull/565 is merged we can use main again.