### PR TITLE
Unify event implementation

### DIFF
--- a/include/ghex/device/cuda/event.hpp
+++ b/include/ghex/device/cuda/event.hpp
@@ -27,7 +27,10 @@ struct cuda_event
     cudaEvent_t           m_event;
     ghex::util::moved_bit m_moved;
 
-    cuda_event() : cuda_event(cudaEventDisableTiming) {}
+    cuda_event()
+    : cuda_event(cudaEventDisableTiming)
+    {
+    }
     explicit cuda_event(unsigned int flags) {
         GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(&m_event, flags))
     };

--- a/include/ghex/device/cuda/event.hpp
+++ b/include/ghex/device/cuda/event.hpp
@@ -27,7 +27,8 @@ struct cuda_event
     cudaEvent_t           m_event;
     ghex::util::moved_bit m_moved;
 
-    cuda_event(unsigned int flags = cudaEventDisableTiming) {
+    cuda_event() : cuda_event(cudaEventDisableTiming) {}
+    explicit cuda_event(unsigned int flags) {
         GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(&m_event, flags))
     };
     cuda_event(const cuda_event&) = delete;
@@ -52,9 +53,6 @@ struct cuda_event
         assert(!m_moved);
         return m_event;
     }
-
-    operator cudaEvent_t&() noexcept { return get(); }
-    operator const cudaEvent_t&() const noexcept { return get(); }
 };
 } // namespace device
 } // namespace ghex

--- a/include/ghex/device/cuda/event.hpp
+++ b/include/ghex/device/cuda/event.hpp
@@ -40,15 +40,7 @@ struct cuda_event
         if (!m_moved) { GHEX_CHECK_CUDA_RESULT_NO_THROW(cudaEventDestroy(m_event)) }
     }
 
-    /**
-     * @brief	Returns `true` if `*this` has been moved, i.e. can no longer be used.
-     *
-     * @todo  The semantic of this function is a bit confusing as a valid object returns
-     *   `false`. It should be changed such that a valid object returns `true` and an
-     *   invalid one returns `false`. This is the behaviour for `GHEX_C_STRUCT` and
-     *   `GHEX_C_MANAGED_STRUCT` but not for `stream` and `cuda_event`.
-     */
-    operator bool() const noexcept { return m_moved; }
+    operator bool() const noexcept { return !m_moved; }
 
     cudaEvent_t& get() noexcept
     {

--- a/include/ghex/device/cuda/event.hpp
+++ b/include/ghex/device/cuda/event.hpp
@@ -27,8 +27,8 @@ struct cuda_event
     cudaEvent_t           m_event;
     ghex::util::moved_bit m_moved;
 
-    cuda_event() {
-        GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(&m_event, cudaEventDisableTiming))
+    cuda_event(unsigned int flags = cudaEventDisableTiming) {
+        GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(&m_event, flags))
     };
     cuda_event(const cuda_event&) = delete;
     cuda_event& operator=(const cuda_event&) = delete;
@@ -52,6 +52,9 @@ struct cuda_event
         assert(!m_moved);
         return m_event;
     }
+
+    operator cudaEvent_t&() noexcept { return get(); }
+    operator const cudaEvent_t&() const noexcept { return get(); }
 };
 } // namespace device
 } // namespace ghex

--- a/include/ghex/device/cuda/event_pool.hpp
+++ b/include/ghex/device/cuda/event_pool.hpp
@@ -70,7 +70,7 @@ struct event_pool
         while (!(m_next_event < m_events.size())) { m_events.emplace_back(cuda_event()); }
 
         const std::size_t event_to_use = m_next_event;
-        assert(!bool(m_events[event_to_use]));
+        assert(bool(m_events[event_to_use]));
         m_next_event += 1;
         return m_events[event_to_use];
     }

--- a/include/ghex/device/cuda/future.hpp
+++ b/include/ghex/device/cuda/future.hpp
@@ -32,7 +32,7 @@ struct future
     T          m_data;
 
     future(T&& data, stream& stream)
-    : m_event{cudaEventDisableTiming} //: m_event{cudaEventDisableTiming | cudaEventBlockingSync}
+    : m_event{}
     , m_data{std::move(data)}
     {
         GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event, stream));
@@ -63,8 +63,7 @@ struct future<void>
     cuda_event m_event;
 
     future(stream& stream)
-    : m_event{cudaEventDisableTiming}
-    //: m_event{cudaEventDisableTiming | cudaEventBlockingSync}
+    : m_event{}
     {
         GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event, stream));
     }

--- a/include/ghex/device/cuda/future.hpp
+++ b/include/ghex/device/cuda/future.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <ghex/config.hpp>
-#include <ghex/util/c_managed_struct.hpp>
+#include <ghex/device/cuda/event.hpp>
 #include <ghex/device/cuda/error.hpp>
 #ifdef GHEX_CUDACC
 #include <ghex/device/cuda/runtime.hpp>
@@ -28,12 +28,7 @@ namespace device
 template<typename T>
 struct future
 {
-    GHEX_C_MANAGED_STRUCT(
-        event_type, cudaEvent_t, [](auto&&... args)
-        { GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(std::forward<decltype(args)>(args)...)) },
-        [](auto& e) { GHEX_CHECK_CUDA_RESULT_NO_THROW(cudaEventDestroy(e)) })
-
-    event_type m_event;
+    cuda_event m_event;
     T          m_data;
 
     future(T&& data, stream& stream)
@@ -65,12 +60,7 @@ struct future
 template<>
 struct future<void>
 {
-    GHEX_C_MANAGED_STRUCT(
-        event_type, cudaEvent_t, [](auto&&... args)
-        { GHEX_CHECK_CUDA_RESULT(cudaEventCreateWithFlags(std::forward<decltype(args)>(args)...)) },
-        [](auto& e) { GHEX_CHECK_CUDA_RESULT_NO_THROW(cudaEventDestroy(e)) })
-
-    event_type m_event;
+    cuda_event m_event;
 
     future(stream& stream)
     : m_event{cudaEventDisableTiming}

--- a/include/ghex/device/cuda/future.hpp
+++ b/include/ghex/device/cuda/future.hpp
@@ -35,7 +35,7 @@ struct future
     : m_event{}
     , m_data{std::move(data)}
     {
-        GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event, stream));
+        GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event.get(), stream));
     }
 
     future(const future&) = delete;
@@ -43,11 +43,11 @@ struct future
     future(future&& other) = default;
     future& operator=(future&&) = default;
 
-    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event)) : true); }
+    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true); }
 
     void wait()
     {
-        if (m_event) GHEX_CHECK_CUDA_RESULT(cudaEventSynchronize(m_event));
+        if (m_event) GHEX_CHECK_CUDA_RESULT(cudaEventSynchronize(m_event.get()));
     }
 
     [[nodiscard]] T get()
@@ -65,7 +65,7 @@ struct future<void>
     future(stream& stream)
     : m_event{}
     {
-        GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event, stream));
+        GHEX_CHECK_CUDA_RESULT(cudaEventRecord(m_event.get(), stream));
     }
 
     future(const future&) = delete;
@@ -73,11 +73,11 @@ struct future<void>
     future(future&& other) = default;
     future& operator=(future&&) = default;
 
-    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event)) : true); }
+    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true); }
 
     void wait()
     {
-        if (m_event) GHEX_CHECK_CUDA_RESULT(cudaEventSynchronize(m_event));
+        if (m_event) GHEX_CHECK_CUDA_RESULT(cudaEventSynchronize(m_event.get()));
     }
 
     void get() { wait(); }

--- a/include/ghex/device/cuda/future.hpp
+++ b/include/ghex/device/cuda/future.hpp
@@ -10,9 +10,9 @@
 #pragma once
 
 #include <ghex/config.hpp>
+#ifdef GHEX_CUDACC
 #include <ghex/device/cuda/event.hpp>
 #include <ghex/device/cuda/error.hpp>
-#ifdef GHEX_CUDACC
 #include <ghex/device/cuda/runtime.hpp>
 #endif
 #include <memory>

--- a/include/ghex/device/cuda/future.hpp
+++ b/include/ghex/device/cuda/future.hpp
@@ -43,7 +43,10 @@ struct future
     future(future&& other) = default;
     future& operator=(future&&) = default;
 
-    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true); }
+    bool test() noexcept
+    {
+        return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true);
+    }
 
     void wait()
     {
@@ -73,7 +76,10 @@ struct future<void>
     future(future&& other) = default;
     future& operator=(future&&) = default;
 
-    bool test() noexcept { return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true); }
+    bool test() noexcept
+    {
+        return (m_event ? (cudaSuccess == cudaEventQuery(m_event.get())) : true);
+    }
 
     void wait()
     {

--- a/include/ghex/device/cuda/stream.hpp
+++ b/include/ghex/device/cuda/stream.hpp
@@ -39,15 +39,7 @@ struct stream
         if (!m_moved) { GHEX_CHECK_CUDA_RESULT_NO_THROW(cudaStreamDestroy(m_stream)) }
     }
 
-    /**
-     * @brief	Returns `true` if `*this` has been moved, i.e. can no longer be used.
-     *
-     * @todo  The semantic of this function is a bit confusing as a valid object returns
-     *   `false`. It should be changed such that a valid object returns `true` and an
-     *   invalid one returns `false`. This is the behaviour for `GHEX_C_STRUCT` and
-     *   `GHEX_C_MANAGED_STRUCT` but not for `stream` and `cuda_event`.
-     */
-    operator bool() const noexcept { return m_moved; }
+    operator bool() const noexcept { return !m_moved; }
 
     operator cudaStream_t() const noexcept
     {


### PR DESCRIPTION
This is on top of #199.

Uses the explicit implementation of a cudaEvent_t RAII wrapper in include/ghex.device/cuda/event.hpp in the device future implementation.