### PR TITLE
Add CSCS CI configuration

### DIFF
--- a/.cscs-ci/container/build.Containerfile
+++ b/.cscs-ci/container/build.Containerfile
@@ -11,7 +11,9 @@ RUN spack -e ci build-env ghex -- \
             -DCMAKE_BUILD_TYPE=Debug \
             -DGHEX_WITH_TESTING=ON \
             -DGHEX_TRANSPORT_BACKEND=$(echo $BACKEND | tr '[:lower:]' '[:upper:]') \
-            -DGHEX_USE_BUNDLED_LIBS=OFF \
+            -DGHEX_USE_BUNDLED_LIBS=ON \
+            -DGHEX_USE_BUNDLED_OOMPH=OFF \
+            -DGHEX_USE_BUNDLED_GRIDTOOLS=OFF \
             -DGHEX_USE_GPU=ON \
             -DGHEX_GPU_TYPE=NVIDIA \
             -DMPIEXEC_EXECUTABLE="" \

--- a/.cscs-ci/container/build.Containerfile
+++ b/.cscs-ci/container/build.Containerfile
@@ -18,6 +18,7 @@ RUN spack -e ci build-env ghex -- \
             -DGHEX_USE_BUNDLED_GRIDTOOLS=OFF \
             -DGHEX_USE_GPU=ON \
             -DGHEX_GPU_TYPE=NVIDIA \
+            -DGHEX_BUILD_PYTHON_BINDINGS=ON \
             -DMPIEXEC_EXECUTABLE="" \
             -DMPIEXEC_NUMPROC_FLAG="" \
             -DMPIEXEC_PREFLAGS="" \

--- a/.cscs-ci/container/build.Containerfile
+++ b/.cscs-ci/container/build.Containerfile
@@ -11,7 +11,9 @@ RUN spack -e ci build-env ghex -- \
             -DCMAKE_BUILD_TYPE=Debug \
             -DGHEX_WITH_TESTING=ON \
             -DGHEX_TRANSPORT_BACKEND=$(echo $BACKEND | tr '[:lower:]' '[:upper:]') \
+            -DGHEX_GIT_SUBMODULE=ON \
             -DGHEX_USE_BUNDLED_LIBS=ON \
+            -DGHEX_USE_BUNDLED_GTEST=ON \
             -DGHEX_USE_BUNDLED_OOMPH=OFF \
             -DGHEX_USE_BUNDLED_GRIDTOOLS=OFF \
             -DGHEX_USE_GPU=ON \

--- a/.cscs-ci/container/build.Containerfile
+++ b/.cscs-ci/container/build.Containerfile
@@ -1,0 +1,21 @@
+ARG DEPS_IMAGE
+FROM $DEPS_IMAGE
+
+COPY . /ghex
+WORKDIR /ghex
+
+ARG BACKEND
+ARG NUM_PROCS
+RUN spack -e ci build-env ghex -- \
+        cmake -G Ninja -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DGHEX_WITH_TESTING=ON \
+            -DGHEX_TRANSPORT_BACKEND=$(echo $BACKEND | tr '[:lower:]' '[:upper:]') \
+            -DGHEX_USE_BUNDLED_LIBS=OFF \
+            -DGHEX_USE_GPU=ON \
+            -DGHEX_GPU_TYPE=NVIDIA \
+            -DMPIEXEC_EXECUTABLE="" \
+            -DMPIEXEC_NUMPROC_FLAG="" \
+            -DMPIEXEC_PREFLAGS="" \
+            -DMPIEXEC_POSTFLAGS="" && \
+    spack -e ci build-env ghex -- cmake --build build -j$NUM_PROCS

--- a/.cscs-ci/container/deps.Containerfile
+++ b/.cscs-ci/container/deps.Containerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG SPACK_SHA
+RUN mkdir -p /opt/spack && \
+    curl -fLsS "https://api.github.com/repos/spack/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
+
+ENV PATH="/opt/spack/bin:$PATH"
+
+ARG SPACK_PACKAGES_SHA
+RUN mkdir -p /opt/spack-packages && \
+    curl -fLsS "https://api.github.com/repos/spack/spack-packages/tarball/$SPACK_PACKAGES_SHA" | tar --strip-components=1 -xz -C /opt/spack-packages
+
+RUN spack repo remove --scope defaults:base builtin && \
+    spack repo add --scope site /opt/spack-packages/repos/spack_repo/builtin
+
+ARG SPACK_ENV_FILE
+COPY $SPACK_ENV_FILE /spack_environment/spack.yaml
+
+ARG NUM_PROCS
+RUN spack external find --all && \
+    spack env create ci /spack_environment/spack.yaml && \
+    spack -e ci concretize -f && \
+    spack -e ci install --jobs $NUM_PROCS --fail-fast --only=dependencies

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -108,14 +108,34 @@ build_libfabric:
 
 .test_parallel_template:
   extends: .test_template_base
-  variables:
-    SLURM_NTASKS: 4
   script:
     # All ranks write to ctest files in Testing, but this can deadlock when
     # writing inside the container.
     - if [[ "${SLURM_PROCID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
     - sleep 1
-    - ctest --test-dir /ghex/build -L "parallel-ranks-4" --output-on-failure --timeout 60
+    - ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
+
+.test_parallel_job:
+  extends: .test_parallel_template
+  image: $BUILD_IMAGE
+
+.test_parallel_mpi:
+  extends: .test_parallel_job
+  needs:
+    - job: build_mpi
+      artifacts: true
+
+.test_parallel_ucx:
+  extends: .test_parallel_job
+  needs:
+    - job: build_ucx
+      artifacts: true
+
+#.test_parallel_libfabric:
+#  extends: .test_parallel_job
+#  needs:
+#    - job: build_libfabric
+#      artifacts: true
 
 test_serial_mpi:
   extends: .test_serial_template
@@ -124,12 +144,20 @@ test_serial_mpi:
       artifacts: true
   image: $BUILD_IMAGE
 
-test_parallel_mpi:
-  extends: .test_parallel_template
-  needs:
-    - job: build_mpi
-      artifacts: true
-  image: $BUILD_IMAGE
+test_parallel_2_mpi:
+  extends: .test_parallel_mpi
+  variables:
+    SLURM_NTASKS: 2
+
+test_parallel_4_mpi:
+  extends: .test_parallel_mpi
+  variables:
+    SLURM_NTASKS: 4
+
+test_parallel_6_mpi:
+  extends: .test_parallel_mpi
+  variables:
+    SLURM_NTASKS: 6
 
 test_serial_ucx:
   extends: .test_serial_template
@@ -138,12 +166,20 @@ test_serial_ucx:
       artifacts: true
   image: $BUILD_IMAGE
 
-test_parallel_ucx:
-  extends: .test_parallel_template
-  needs:
-    - job: build_ucx
-      artifacts: true
-  image: $BUILD_IMAGE
+test_parallel_2_ucx:
+  extends: .test_parallel_ucx
+  variables:
+    SLURM_NTASKS: 2
+
+test_parallel_4_ucx:
+  extends: .test_parallel_ucx
+  variables:
+    SLURM_NTASKS: 4
+
+test_parallel_6_ucx:
+  extends: .test_parallel_ucx
+  variables:
+    SLURM_NTASKS: 6
 
 # TODO: Libfabric tests are currently failing on Alps and need to be fixed.
 # test_serial_libfabric:
@@ -153,9 +189,17 @@ test_parallel_ucx:
 #       artifacts: true
 #   image: $BUILD_IMAGE
 
-# test_parallel_libfabric:
-#   extends: .test_parallel_template
-#   needs:
-#     - job: build_libfabric
-#       artifacts: true
-#   image: $BUILD_IMAGE
+# test_parallel_2_libfabric:
+#   extends: .test_parallel_libfabric
+#   variables:
+#     SLURM_NTASKS: 2
+#
+# test_parallel_4_libfabric:
+#   extends: .test_parallel_libfabric
+#   variables:
+#     SLURM_NTASKS: 4
+#
+# test_parallel_6_libfabric:
+#   extends: .test_parallel_libfabric
+#   variables:
+#     SLURM_NTASKS: 6

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -145,16 +145,17 @@ test_parallel_ucx:
       artifacts: true
   image: $BUILD_IMAGE
 
-test_serial_libfabric:
-  extends: .test_serial_template
-  needs:
-    - job: build_libfabric
-      artifacts: true
-  image: $BUILD_IMAGE
+# TODO: Libfabric tests are currently failing on Alps and need to be fixed.
+# test_serial_libfabric:
+#   extends: .test_serial_template
+#   needs:
+#     - job: build_libfabric
+#       artifacts: true
+#   image: $BUILD_IMAGE
 
-test_parallel_libfabric:
-  extends: .test_parallel_template
-  needs:
-    - job: build_libfabric
-      artifacts: true
-  image: $BUILD_IMAGE
+# test_parallel_libfabric:
+#   extends: .test_parallel_template
+#   needs:
+#     - job: build_libfabric
+#       artifacts: true
+#   image: $BUILD_IMAGE

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -82,7 +82,6 @@ build_libfabric:
 .test_template_base:
   extends: .container-runner-clariden-gh200
   variables:
-    SLURM_JOB_NUM_NODES: 1
     SLURM_GPUS_PER_TASK: 1
     SLURM_TIMELIMIT: '5:00'
     SLURM_PARTITION: normal

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -4,7 +4,7 @@ include:
 variables:
   BASE_IMAGE: jfrog.svc.cscs.ch/docker-group-csstaff/alps-images/ngc-pytorch:26.01-py3-alps4-dev
   SPACK_SHA: v1.1.1
-  SPACK_PACKAGES_SHA: 5f24787b5cd3c2356d9a8188b989ceb5307299c6 # https://github.com/msimberg/spack-packages/tree/oomph-nccl
+  SPACK_PACKAGES_SHA: bc93746ce936d6653271b6e98f6df6ee28f64e84 # develop on 2026-03-25
   FF_TIMESTAMPS: true
 
 .build_deps_template:

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -105,7 +105,7 @@ build_libfabric:
   script:
     # All ranks write to ctest files in Testing, but this can deadlock when
     # writing inside the container.
-    - if [[ "${SLURM_PROCID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
+    - if [[ "${SLURM_LOCALID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
     - until [[ -L /ghex/build/Testing ]]; do sleep 1; done
     - ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
 

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -96,7 +96,7 @@ build_libfabric:
   variables:
     SLURM_NTASKS: 1
   script:
-    - ctest --test-dir /ghex/build -L "serial" --output-on-failure --timeout 60 --parallel 8
+    - spack -e ci build-env ghex -- ctest --test-dir /ghex/build -L "serial" --output-on-failure --timeout 60 --parallel 8
 
 .test_parallel_template:
   extends: .test_template_base
@@ -105,7 +105,7 @@ build_libfabric:
     # writing inside the container.
     - if [[ "${SLURM_LOCALID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
     - until [[ -L /ghex/build/Testing ]]; do sleep 1; done
-    - ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
+    - spack -e ci build-env ghex -- ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
 
 .test_parallel_job:
   extends: .test_parallel_template

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -11,7 +11,6 @@ variables:
   extends: .container-builder-cscs-gh200
   timeout: 1 hour
   before_script:
-    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin || true
     - export DOCKERFILE_SHA=`sha256sum .cscs-ci/container/deps.Containerfile | head -c 16`
     - export ENV_FILE_SHA=`sha256sum ${SPACK_ENV_FILE} | head -c 16`
     - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_SHA-$SPACK_PACKAGES_SHA-$ENV_FILE_SHA | sha256sum - | head -c 16`
@@ -45,7 +44,6 @@ build_deps_libfabric:
   extends: .container-builder-cscs-gh200
   timeout: 15 minutes
   before_script:
-    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin || true
     - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/ghex-build-$BACKEND:$CI_COMMIT_SHA
     - echo -e "BUILD_IMAGE=$PERSIST_IMAGE_NAME" >> build-${BACKEND}.env
   variables:

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -1,0 +1,160 @@
+include:
+  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
+
+variables:
+  BASE_IMAGE: jfrog.svc.cscs.ch/docker-group-csstaff/alps-images/ngc-pytorch:26.01-py3-alps4-dev
+  SPACK_SHA: v1.1.1
+  SPACK_PACKAGES_SHA: 5f24787b5cd3c2356d9a8188b989ceb5307299c6 # https://github.com/msimberg/spack-packages/tree/oomph-nccl
+  FF_TIMESTAMPS: true
+
+.build_deps_template:
+  timeout: 1 hour
+  before_script:
+    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin || true
+    - export DOCKERFILE_SHA=`sha256sum .cscs-ci/container/deps.Containerfile | head -c 16`
+    - export ENV_FILE_SHA=`sha256sum ${SPACK_ENV_FILE} | head -c 16`
+    - export CONFIG_TAG=`echo $DOCKERFILE_SHA-$BASE_IMAGE-$SPACK_SHA-$SPACK_PACKAGES_SHA-$ENV_FILE_SHA | sha256sum - | head -c 16`
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/ghex-spack-deps-$BACKEND:$CONFIG_TAG
+    - echo -e "CONFIG_TAG=$CONFIG_TAG" >> base-${BACKEND}.env
+    - echo -e "DEPS_IMAGE=$PERSIST_IMAGE_NAME" >> base-${BACKEND}.env
+  variables:
+    DOCKERFILE: .cscs-ci/container/deps.Containerfile
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE", "SPACK_SHA", "SPACK_PACKAGES_SHA", "SPACK_ENV_FILE"]'
+    SPACK_ENV_FILE: .cscs-ci/spack/$BACKEND.yaml
+  artifacts:
+    reports:
+      dotenv: base-${BACKEND}.env
+
+build_deps_mpi:
+  variables:
+    BACKEND: mpi
+  extends:
+    - .container-builder-cscs-gh200
+    - .build_deps_template
+
+build_deps_ucx:
+  variables:
+    BACKEND: ucx
+  extends:
+    - .container-builder-cscs-gh200
+    - .build_deps_template
+
+build_deps_libfabric:
+  variables:
+    BACKEND: libfabric
+  extends:
+    - .container-builder-cscs-gh200
+    - .build_deps_template
+
+.build_template:
+  extends: .container-builder-cscs-gh200
+  timeout: 15 minutes
+  before_script:
+    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin || true
+    - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/public/ghex-build-$BACKEND:$CI_COMMIT_SHA
+    - echo -e "BUILD_IMAGE=$PERSIST_IMAGE_NAME" >> build-${BACKEND}.env
+  variables:
+    DOCKERFILE: .cscs-ci/container/build.Containerfile
+    DOCKER_BUILD_ARGS: '["DEPS_IMAGE", "BACKEND"]'
+  artifacts:
+    reports:
+      dotenv: build-${BACKEND}.env
+
+build_mpi:
+  variables:
+    BACKEND: mpi
+  extends: .build_template
+  needs:
+    - job: build_deps_mpi
+      artifacts: true
+
+build_ucx:
+  variables:
+    BACKEND: ucx
+  extends: .build_template
+  needs:
+    - job: build_deps_ucx
+      artifacts: true
+
+build_libfabric:
+  variables:
+    BACKEND: libfabric
+  extends: .build_template
+  needs:
+    - job: build_deps_libfabric
+      artifacts: true
+
+.test_template_base:
+  extends: .container-runner-clariden-gh200
+  variables:
+    SLURM_JOB_NUM_NODES: 1
+    SLURM_GPUS_PER_TASK: 1
+    SLURM_TIMELIMIT: '5:00'
+    SLURM_PARTITION: normal
+    SLURM_MPI_TYPE: pmix
+    SLURM_NETWORK: disable_rdzv_get
+    SLURM_LABELIO: 1
+    SLURM_UNBUFFEREDIO: 1
+    PMIX_MCA_psec: native
+    PMIX_MCA_gds: "^shmem2"
+    USE_MPI: NO
+
+.test_serial_template:
+  extends: .test_template_base
+  variables:
+    SLURM_NTASKS: 1
+  script:
+    - ctest --test-dir /ghex/build -L "serial" --output-on-failure --timeout 60 --parallel 8
+
+.test_parallel_template:
+  extends: .test_template_base
+  variables:
+    SLURM_NTASKS: 4
+  script:
+    # All ranks write to ctest files in Testing, but this can deadlock when
+    # writing inside the container.
+    - if [[ "${SLURM_PROCID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
+    - sleep 1
+    - ctest --test-dir /ghex/build -L "parallel-ranks-4" --output-on-failure --timeout 60
+
+test_serial_mpi:
+  extends: .test_serial_template
+  needs:
+    - job: build_mpi
+      artifacts: true
+  image: $BUILD_IMAGE
+
+test_parallel_mpi:
+  extends: .test_parallel_template
+  needs:
+    - job: build_mpi
+      artifacts: true
+  image: $BUILD_IMAGE
+
+test_serial_ucx:
+  extends: .test_serial_template
+  needs:
+    - job: build_ucx
+      artifacts: true
+  image: $BUILD_IMAGE
+
+test_parallel_ucx:
+  extends: .test_parallel_template
+  needs:
+    - job: build_ucx
+      artifacts: true
+  image: $BUILD_IMAGE
+
+test_serial_libfabric:
+  extends: .test_serial_template
+  needs:
+    - job: build_libfabric
+      artifacts: true
+  image: $BUILD_IMAGE
+
+test_parallel_libfabric:
+  extends: .test_parallel_template
+  needs:
+    - job: build_libfabric
+      artifacts: true
+  image: $BUILD_IMAGE

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -8,6 +8,7 @@ variables:
   FF_TIMESTAMPS: true
 
 .build_deps_template:
+  extends: .container-builder-cscs-gh200
   timeout: 1 hour
   before_script:
     - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin || true
@@ -26,25 +27,19 @@ variables:
       dotenv: base-${BACKEND}.env
 
 build_deps_mpi:
+  extends: .build_deps_template
   variables:
     BACKEND: mpi
-  extends:
-    - .container-builder-cscs-gh200
-    - .build_deps_template
 
 build_deps_ucx:
+  extends: .build_deps_template
   variables:
     BACKEND: ucx
-  extends:
-    - .container-builder-cscs-gh200
-    - .build_deps_template
 
 build_deps_libfabric:
+  extends: .build_deps_template
   variables:
     BACKEND: libfabric
-  extends:
-    - .container-builder-cscs-gh200
-    - .build_deps_template
 
 .build_template:
   extends: .container-builder-cscs-gh200
@@ -61,25 +56,25 @@ build_deps_libfabric:
       dotenv: build-${BACKEND}.env
 
 build_mpi:
+  extends: .build_template
   variables:
     BACKEND: mpi
-  extends: .build_template
   needs:
     - job: build_deps_mpi
       artifacts: true
 
 build_ucx:
+  extends: .build_template
   variables:
     BACKEND: ucx
-  extends: .build_template
   needs:
     - job: build_deps_ucx
       artifacts: true
 
 build_libfabric:
+  extends: .build_template
   variables:
     BACKEND: libfabric
-  extends: .build_template
   needs:
     - job: build_deps_libfabric
       artifacts: true

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -107,7 +107,7 @@ build_libfabric:
     # All ranks write to ctest files in Testing, but this can deadlock when
     # writing inside the container.
     - if [[ "${SLURM_PROCID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
-    - sleep 1
+    - until [[ -d /ghex/build/Testing ]]; do sleep 1; done
     - ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
 
 .test_parallel_job:

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -107,7 +107,7 @@ build_libfabric:
     # All ranks write to ctest files in Testing, but this can deadlock when
     # writing inside the container.
     - if [[ "${SLURM_PROCID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
-    - until [[ -d /ghex/build/Testing ]]; do sleep 1; done
+    - until [[ -L /ghex/build/Testing ]]; do sleep 1; done
     - ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
 
 .test_parallel_job:

--- a/.cscs-ci/spack/libfabric.yaml
+++ b/.cscs-ci/spack/libfabric.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=libfabric +cuda cuda_arch=90a
+  - ghex@master backend=libfabric +cuda cuda_arch=90a +python
   view: false
   concretizer:
     unify: true

--- a/.cscs-ci/spack/libfabric.yaml
+++ b/.cscs-ci/spack/libfabric.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=libfabric +cuda
+  - ghex@master backend=libfabric +cuda cuda_arch=90a
   view: false
   concretizer:
     unify: true

--- a/.cscs-ci/spack/libfabric.yaml
+++ b/.cscs-ci/spack/libfabric.yaml
@@ -1,0 +1,6 @@
+spack:
+  specs:
+  - ghex@master backend=libfabric +cuda
+  view: false
+  concretizer:
+    unify: true

--- a/.cscs-ci/spack/mpi.yaml
+++ b/.cscs-ci/spack/mpi.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=mpi +cuda cuda_arch=90a
+  - ghex@master backend=mpi +cuda cuda_arch=90a +python
   view: false
   concretizer:
     unify: true

--- a/.cscs-ci/spack/mpi.yaml
+++ b/.cscs-ci/spack/mpi.yaml
@@ -1,0 +1,6 @@
+spack:
+  specs:
+  - ghex@master backend=mpi +cuda
+  view: false
+  concretizer:
+    unify: true

--- a/.cscs-ci/spack/mpi.yaml
+++ b/.cscs-ci/spack/mpi.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=mpi +cuda
+  - ghex@master backend=mpi +cuda cuda_arch=90a
   view: false
   concretizer:
     unify: true

--- a/.cscs-ci/spack/ucx.yaml
+++ b/.cscs-ci/spack/ucx.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=ucx +cuda cuda_arch=90a
+  - ghex@master backend=ucx +cuda cuda_arch=90a +python
   view: false
   concretizer:
     unify: true

--- a/.cscs-ci/spack/ucx.yaml
+++ b/.cscs-ci/spack/ucx.yaml
@@ -1,0 +1,6 @@
+spack:
+  specs:
+  - ghex@master backend=ucx +cuda
+  view: false
+  concretizer:
+    unify: true

--- a/.cscs-ci/spack/ucx.yaml
+++ b/.cscs-ci/spack/ucx.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - ghex@master backend=ucx +cuda
+  - ghex@master backend=ucx +cuda cuda_arch=90a
   view: false
   concretizer:
     unify: true

--- a/cmake/ghex_reg_test.cmake
+++ b/cmake/ghex_reg_test.cmake
@@ -21,7 +21,7 @@ function(ghex_reg_test t_)
     add_test(
         NAME ${t}
         COMMAND $<TARGET_FILE:${t}>)
-    set_tests_properties(${t} PROPERTIES RUN_SERIAL ON)
+    set_tests_properties(${t} PROPERTIES RUN_SERIAL ON LABELS "serial")
 endfunction()
 
 function(ghex_reg_parallel_test t_ n mt)
@@ -38,9 +38,13 @@ function(ghex_reg_parallel_test t_ n mt)
     ghex_link_to_oomph(${t})
     # workaround for clang+openmp
     target_link_libraries(${t} PRIVATE $<$<CXX_COMPILER_ID:Clang>:$<LINK_ONLY:-fopenmp=libomp>>)
-    add_test(
-        NAME ${t}
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
-            $<TARGET_FILE:${t}> ${MPIEXEC_POSTFLAGS})
-    set_tests_properties(${t} PROPERTIES RUN_SERIAL ON)
+    if("${MPIEXEC_EXECUTABLE}" STREQUAL "")
+      add_test(NAME ${t} COMMAND $<TARGET_FILE:${t}>)
+    else()
+      add_test(
+          NAME ${t}
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
+              $<TARGET_FILE:${t}> ${MPIEXEC_POSTFLAGS})
+    endif()
+    set_tests_properties(${t} PROPERTIES RUN_SERIAL ON LABELS "parallel-ranks-${n}")
 endfunction()

--- a/test/bindings/fhex/CMakeLists.txt
+++ b/test/bindings/fhex/CMakeLists.txt
@@ -14,10 +14,15 @@ function(ghex_reg_parallel_test_f t n)
     ghex_link_to_oomph(${t})
     ## workaround for clang+openmp
     #target_link_libraries(${t} PRIVATE $<$<CXX_COMPILER_ID:Clang>:$<LINK_ONLY:-fopenmp=libomp>>)
-    add_test(
-        NAME ${t}
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
-            $<TARGET_FILE:${t}> ${MPIEXEC_POSTFLAGS})
+    if("${MPIEXEC_EXECUTABLE}" STREQUAL "")
+      add_test(NAME ${t} COMMAND $<TARGET_FILE:${t}>)
+    else()
+      add_test(
+          NAME ${t}
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
+              $<TARGET_FILE:${t}> ${MPIEXEC_POSTFLAGS})
+    endif()
+    set_tests_properties(${t} PROPERTIES RUN_SERIAL ON LABELS "parallel-ranks-${n}")
 endfunction()
 
 ghex_reg_parallel_test_f(f_context 4)

--- a/test/bindings/python/CMakeLists.txt
+++ b/test/bindings/python/CMakeLists.txt
@@ -68,18 +68,25 @@ function(ghex_reg_pytest t)
         NAME py_${t}
         COMMAND ${venv_dir}/bin/python -m pytest -s ${CMAKE_CURRENT_BINARY_DIR}/test_${t}.py
         WORKING_DIRECTORY ${pyghex_test_workdir})
-    set_tests_properties(py_${t} PROPERTIES RUN_SERIAL ON)
+    set_tests_properties(py_${t} PROPERTIES RUN_SERIAL ON LABELS "serial")
 endfunction()
 
 function(ghex_reg_parallel_pytest t n)
     copy_files(TARGET pyghex_tests DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/test_${t}.py)
-    add_test(
-        NAME py_${t}_parallel
-        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
-        ${venv_dir}/bin/python -m pytest -s --with-mpi ${CMAKE_CURRENT_BINARY_DIR}/test_${t}.py
-        WORKING_DIRECTORY ${pyghex_test_workdir})
-    set_tests_properties(py_${t}_parallel PROPERTIES RUN_SERIAL ON)
+    if("${MPIEXEC_EXECUTABLE}" STREQUAL "")
+      add_test(
+          NAME py_${t}_parallel
+          COMMAND ${venv_dir}/bin/python -m pytest -s --with-mpi ${CMAKE_CURRENT_BINARY_DIR}/test_${t}.py
+          WORKING_DIRECTORY ${pyghex_test_workdir})
+    else()
+      add_test(
+          NAME py_${t}_parallel
+          COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${n} ${MPIEXEC_PREFLAGS}
+          ${venv_dir}/bin/python -m pytest -s --with-mpi ${CMAKE_CURRENT_BINARY_DIR}/test_${t}.py
+          WORKING_DIRECTORY ${pyghex_test_workdir})
+    endif()
+    set_tests_properties(py_${t}_parallel PROPERTIES RUN_SERIAL ON LABELS "parallel-ranks-${n}")
 endfunction()
 
 ghex_reg_pytest(context)


### PR DESCRIPTION
Follows the structure of https://github.com/ghex-org/oomph/pull/59 for oomph. Enables ucx and mpi backends in CI. Still keeps libfabric disabled for the same reason as it was disabled in oomph (issues during initialization, likely a configuration issue or similar).