### PR TITLE
Make sure the pyghex library explicitly links to oomph

### DIFF
--- a/bindings/python/src/_pyghex/CMakeLists.txt
+++ b/bindings/python/src/_pyghex/CMakeLists.txt
@@ -52,11 +52,8 @@ set_target_properties(pyghex PROPERTIES
 # This dependency has to be spelt out again, despite being added to
 # pyghex_obj because CMake.
 target_link_libraries(pyghex PRIVATE ghex)
-target_link_libraries(pyghex PRIVATE ghex_common)
-target_link_libraries(pyghex_obj PRIVATE ghex_common)
 ghex_link_to_oomph(ghex)
 ghex_link_to_oomph(pyghex)
-ghex_link_to_oomph(pyghex_obj)
 
 # Set RPaths such that the python module is able to find libghex
 include(ghex_rpath)

--- a/bindings/python/src/_pyghex/CMakeLists.txt
+++ b/bindings/python/src/_pyghex/CMakeLists.txt
@@ -55,6 +55,8 @@ target_link_libraries(pyghex PRIVATE ghex)
 target_link_libraries(pyghex PRIVATE ghex_common)
 target_link_libraries(pyghex_obj PRIVATE ghex_common)
 ghex_link_to_oomph(ghex)
+ghex_link_to_oomph(pyghex)
+ghex_link_to_oomph(pyghex_obj)
 
 # Set RPaths such that the python module is able to find libghex
 include(ghex_rpath)

--- a/bindings/python/src/_pyghex/CMakeLists.txt
+++ b/bindings/python/src/_pyghex/CMakeLists.txt
@@ -52,6 +52,8 @@ set_target_properties(pyghex PROPERTIES
 # This dependency has to be spelt out again, despite being added to
 # pyghex_obj because CMake.
 target_link_libraries(pyghex PRIVATE ghex)
+target_link_libraries(pyghex PRIVATE ghex_common)
+target_link_libraries(pyghex_obj PRIVATE ghex_common)
 ghex_link_to_oomph(ghex)
 
 # Set RPaths such that the python module is able to find libghex


### PR DESCRIPTION
The target already explicitly links to oomph::oomph, but oomph::oomph is an interface-only target. pyghex was not explicitly linking to the actual implementation library, i.e. oomph_mpi/libfabric/etc. It seems that somehow the library automatically found on linux, and on macos before #198. However, after #198 building the GHEX python package broke with unresolved symbols on macos (thanks @stubbiali for testing and pointing this out).

This PR simply explicitly links to the oomph_* library.