### PR TITLE
Replace `__HIP_PLATFORM_HCC__` with `__HIP_PLATFORM_AMD__`

### DIFF
--- a/bindings/python/src/_pyghex/structured/regular/field_descriptor.cpp
+++ b/bindings/python/src/_pyghex/structured/regular/field_descriptor.cpp
@@ -52,7 +52,7 @@ struct ndarray_device_type<ghex::cpu>
 template<>
 struct ndarray_device_type<ghex::gpu>
 {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     using type = nanobind::device::rocm;
 #else
     using type = nanobind::device::cuda;

--- a/bindings/python/src/_pyghex/unstructured/field_descriptor.cpp
+++ b/bindings/python/src/_pyghex/unstructured/field_descriptor.cpp
@@ -42,7 +42,7 @@ struct ndarray_device_type<ghex::cpu>
 template<>
 struct ndarray_device_type<ghex::gpu>
 {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     using type = nanobind::device::rocm;
 #else
     using type = nanobind::device::cuda;


### PR DESCRIPTION
Along with https://github.com/GridTools/gridtools/pull/1830 and https://github.com/ghex-org/hwmalloc/pull/52, this PR is needed to build the Python bindings on LUMI using the latest software stack (LUMI/25.03), .