### PR TITLE
Add minimum versions for cmake and scikit-build-core build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 build-backend = 'scikit_build_core.build'
 requires = [
-    'cmake',
+    'cmake>=3.21',
     'nanobind>=1.3.0',
-    'scikit-build-core'
+    'scikit-build-core>=0.5'
 ]
 
 [project]


### PR DESCRIPTION
Pin cmake and scikit-build-core in [build-system].requires to the minimums already declared under [tool.scikit-build] (cmake.minimum-version = '3.21' and minimum-version = '0.5'), so the build-time tool requirements are consistent across the file.

Fixes #213