### PR TITLE
Add scheduled exchange to structured python bindings and test on stream

### DIFF
--- a/bindings/python/src/_pyghex/cuda_stream.hpp
+++ b/bindings/python/src/_pyghex/cuda_stream.hpp
@@ -1,0 +1,84 @@
+/*
+ * ghex-org
+ *
+ * Copyright (c) 2014-2023, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include <ghex/config.hpp>
+
+#if defined(GHEX_CUDACC)
+
+#include <cstdint>
+#include <sstream>
+#include <type_traits>
+
+#include <ghex/device/cuda/runtime.hpp>
+
+#include <nanobind/nanobind.h>
+
+namespace pyghex
+{
+
+// Convert a Python stream object into a CUDA/HIP stream handle. The following
+// Python objects are understood:
+// - `None` is interpreted as the default stream, i.e. `nullptr`.
+// - an object implementing Nvidia's `__cuda_stream__` protocol, see
+//   https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
+// - a CuPy stream, which exposes the stream handle via its `.ptr` attribute, see
+//   https://docs.cupy.dev/en/latest/reference/generated/cupy.cuda.Stream.html#cupy-cuda-stream
+inline cudaStream_t
+extract_cuda_stream(nanobind::object python_stream)
+{
+    static_assert(std::is_pointer<cudaStream_t>::value);
+    if (python_stream.is_none())
+    {
+        // NOTE: This is very C++ like, maybe remove and consider as an error?
+        return static_cast<cudaStream_t>(nullptr);
+    }
+    else
+    {
+        if (nanobind::hasattr(python_stream, "__cuda_stream__"))
+        {
+            nanobind::tuple cuda_stream_protocol =
+                nanobind::cast<nanobind::tuple>(python_stream.attr("__cuda_stream__")());
+            if (cuda_stream_protocol.size() != 2)
+            {
+                std::stringstream error;
+                error << "Expected a tuple of length 2, but got one with length "
+                      << cuda_stream_protocol.size();
+                throw nanobind::type_error(error.str().c_str());
+            }
+
+            const auto protocol_version = nanobind::cast<std::size_t>(cuda_stream_protocol[0]);
+            if (protocol_version != 0)
+            {
+                std::stringstream error;
+                error << "Expected `__cuda_stream__` protocol version 0, but got "
+                      << protocol_version;
+                throw nanobind::type_error(error.str().c_str());
+            }
+
+            const auto stream_address = nanobind::cast<std::uintptr_t>(cuda_stream_protocol[1]);
+            return reinterpret_cast<cudaStream_t>(stream_address);
+        }
+        else if (nanobind::hasattr(python_stream, "ptr"))
+        {
+            std::uintptr_t stream_address =
+                nanobind::cast<std::uintptr_t>(python_stream.attr("ptr"));
+            return reinterpret_cast<cudaStream_t>(stream_address);
+        }
+        // TODO: Find out of how to extract the typename, i.e. `type(python_stream).__name__`.
+        std::stringstream error;
+        error << "Failed to convert the stream object into a CUDA stream.";
+        throw nanobind::type_error(error.str().c_str());
+    }
+}
+
+} // namespace pyghex
+
+#endif

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
@@ -13,6 +13,7 @@
 #include <ghex/structured/pattern.hpp>
 
 #include <context_shim.hpp>
+#include <cuda_stream.hpp>
 #include <register_class.hpp>
 #include <structured/regular/field_descriptor.hpp>
 #include <structured/regular/communication_object.hpp>
@@ -47,7 +48,14 @@ register_communication_object(nanobind::module_& m)
 
             auto _handle = register_class<handle_type>(m);
 
-            _handle.def("wait", &handle_type::wait)
+            _handle
+                .def("wait", &handle_type::wait)
+#if defined(GHEX_CUDACC)
+                .def(
+                    "schedule_wait", [](handle_type& h, nanobind::object python_stream)
+                    { return h.schedule_wait(extract_cuda_stream(python_stream)); },
+                    nanobind::arg("stream").none())
+#endif
                 .def("is_ready", &handle_type::is_ready)
                 .def("progress", &handle_type::progress);
 
@@ -77,7 +85,46 @@ register_communication_object(nanobind::module_& m)
                             [](communication_object_shim& co, buffer_info_type& b0,
                                 buffer_info_type& b1, buffer_info_type& b2)
                             { return co.exchange(b0, b1, b2); },
-                            nanobind::keep_alive<0, 1>());
+                            nanobind::keep_alive<0, 1>())
+#if defined(GHEX_CUDACC)
+                        .def(
+                            "schedule_exchange",
+                            [](communication_object_shim& co, nanobind::object python_stream,
+                                std::vector<buffer_info_type> b) {
+                                return co.schedule_exchange(extract_cuda_stream(python_stream),
+                                    b.begin(), b.end());
+                            },
+                            nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
+                            nanobind::arg("patterns"))
+                        .def(
+                            "schedule_exchange",
+                            [](communication_object_shim& co, nanobind::object python_stream,
+                                buffer_info_type& b)
+                            { return co.schedule_exchange(extract_cuda_stream(python_stream), b); },
+                            nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
+                            nanobind::arg("b"))
+                        .def(
+                            "schedule_exchange",
+                            [](communication_object_shim& co, nanobind::object python_stream,
+                                buffer_info_type& b0, buffer_info_type& b1) {
+                                return co.schedule_exchange(extract_cuda_stream(python_stream), b0,
+                                    b1);
+                            },
+                            nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
+                            nanobind::arg("b0"), nanobind::arg("b1"))
+                        .def(
+                            "schedule_exchange",
+                            [](communication_object_shim& co, nanobind::object python_stream,
+                                buffer_info_type& b0, buffer_info_type& b1, buffer_info_type& b2) {
+                                return co.schedule_exchange(extract_cuda_stream(python_stream), b0,
+                                    b1, b2);
+                            },
+                            nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
+                            nanobind::arg("b0"), nanobind::arg("b1"), nanobind::arg("b2"))
+                        .def("has_scheduled_exchange", [](communication_object_shim& co) -> bool
+                            { return co.has_scheduled_exchange(); })
+#endif // end scheduled exchange
+                        ;
                 });
         });
 

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.cpp
@@ -34,6 +34,11 @@ register_communication_object(nanobind::module_& m)
 {
     auto _communication_object = register_class<communication_object_shim>(m);
 
+#if defined(GHEX_CUDACC)
+    _communication_object.def("has_scheduled_exchange",
+        [](communication_object_shim& co) -> bool { return co.has_scheduled_exchange(); });
+#endif
+
     gridtools::for_each<
         gridtools::meta::transform<gridtools::meta::list, communication_object_specializations>>(
         [&m, &_communication_object](auto l)
@@ -121,8 +126,6 @@ register_communication_object(nanobind::module_& m)
                             },
                             nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
                             nanobind::arg("b0"), nanobind::arg("b1"), nanobind::arg("b2"))
-                        .def("has_scheduled_exchange", [](communication_object_shim& co) -> bool
-                            { return co.has_scheduled_exchange(); })
 #endif // end scheduled exchange
                         ;
                 });

--- a/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
+++ b/bindings/python/src/_pyghex/structured/regular/communication_object.hpp
@@ -11,6 +11,10 @@
 #include <ghex/communication_object.hpp>
 #include <structured/types.hpp>
 
+#ifdef GHEX_CUDACC
+#include <ghex/device/cuda/runtime.hpp>
+#endif
+
 #include <iterator>
 #include <tuple>
 #include <type_traits>
@@ -64,6 +68,39 @@ struct communication_object_shim
             std::make_index_sequence<sizeof...(Its) / 2>());
     }
 
+#if defined(GHEX_CUDACC)
+    // scheduled exchange of buffer info objects, synchronized with a cuda stream
+    template<typename... Patterns, typename... Archs, typename... Fields>
+    auto schedule_exchange(cudaStream_t stream, ghex::buffer_info<Patterns, Archs, Fields>&... b)
+    {
+        return get_co<gridtools::meta::list<Patterns...>>().schedule_exchange(stream, b...);
+    }
+
+    // scheduled exchange of iterator pairs pointing to buffer info ranges
+    template<typename... Its>
+    auto schedule_exchange(cudaStream_t stream, Its... its)
+    {
+        // need even number of iterators (begin and end)
+        static_assert(sizeof...(Its) % 2 == 0);
+        return schedule_exchange_from_iterators(stream, std::make_tuple(std::move(its)...),
+            std::make_index_sequence<sizeof...(Its) / 2>());
+    }
+
+    // query whether a scheduled exchange is still active on the held communication object
+    bool has_scheduled_exchange() const
+    {
+        return std::visit(
+            [](auto const& co) -> bool
+            {
+                if constexpr (std::is_same_v<std::decay_t<decltype(co)>, std::monostate>)
+                    return false;
+                else
+                    return co.has_scheduled_exchange();
+            },
+            m);
+    }
+#endif
+
   private:
     // extractors for nested typedefs
     template<typename It>
@@ -83,6 +120,20 @@ struct communication_object_shim
         return get_co<gridtools::meta::transform<get_pattern_t, begins>>().exchange(
             std::get<Is>(t)..., std::get<Is + half_size>(t)...);
     }
+
+#if defined(GHEX_CUDACC)
+    // helper function for iterators
+    template<typename... Its, std::size_t... Is>
+    auto schedule_exchange_from_iterators(cudaStream_t stream, std::tuple<Its...> t,
+        std::index_sequence<Is...>)
+    {
+        // every second iterator is a begin
+        using begins = decltype(std::make_tuple(std::get<Is * 2>(t)...));
+        static constexpr std::size_t half_size = sizeof...(Is);
+        return get_co<gridtools::meta::transform<get_pattern_t, begins>>().schedule_exchange(stream,
+            std::get<Is>(t)..., std::get<Is + half_size>(t)...);
+    }
+#endif
 
     // get the required communcation object specialization from the variant based on a list of pattern types
     // - will initialize the communication object if the variant is empty

--- a/bindings/python/src/_pyghex/unstructured/communication_object.cpp
+++ b/bindings/python/src/_pyghex/unstructured/communication_object.cpp
@@ -8,18 +8,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <cstdint>
-#include <sstream>
 
 #include <gridtools/common/for_each.hpp>
 
 #include <ghex/buffer_info.hpp>
 #include <ghex/unstructured/pattern.hpp>
 
-#ifdef GHEX_CUDACC
-#include <ghex/device/cuda/runtime.hpp>
-#endif
-
 #include <context_shim.hpp>
+#include <cuda_stream.hpp>
 #include <register_class.hpp>
 #include <unstructured/field_descriptor.hpp>
 #include <unstructured/communication_object.hpp>
@@ -32,60 +28,6 @@ namespace pyghex
 {
 namespace unstructured
 {
-namespace
-{
-#if defined(GHEX_CUDACC)
-cudaStream_t
-extract_cuda_stream(nanobind::object python_stream)
-{
-    static_assert(std::is_pointer<cudaStream_t>::value);
-    if (python_stream.is_none())
-    {
-        // NOTE: This is very C++ like, maybe remove and consider as an error?
-        return static_cast<cudaStream_t>(nullptr);
-    }
-    else
-    {
-        if (nanobind::hasattr(python_stream, "__cuda_stream__"))
-        {
-            // CUDA stream protocol: https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
-            nanobind::tuple cuda_stream_protocol =
-                nanobind::cast<nanobind::tuple>(python_stream.attr("__cuda_stream__")());
-            if (cuda_stream_protocol.size() != 2)
-            {
-                std::stringstream error;
-                error << "Expected a tuple of length 2, but got one with length "
-                      << cuda_stream_protocol.size();
-                throw nanobind::type_error(error.str().c_str());
-            }
-
-            const auto protocol_version = nanobind::cast<std::size_t>(cuda_stream_protocol[0]);
-            if (protocol_version != 0)
-            {
-                std::stringstream error;
-                error << "Expected `__cuda_stream__` protocol version 0, but got "
-                      << protocol_version;
-                throw nanobind::type_error(error.str().c_str());
-            }
-
-            const auto stream_address = nanobind::cast<std::uintptr_t>(cuda_stream_protocol[1]);
-            return reinterpret_cast<cudaStream_t>(stream_address);
-        }
-        else if (nanobind::hasattr(python_stream, "ptr"))
-        {
-            // CuPy stream: See https://docs.cupy.dev/en/latest/reference/generated/cupy.cuda.Stream.html#cupy-cuda-stream
-            std::uintptr_t stream_address =
-                nanobind::cast<std::uintptr_t>(python_stream.attr("ptr"));
-            return reinterpret_cast<cudaStream_t>(stream_address);
-        }
-        // TODO: Find out of how to extract the typename, i.e. `type(python_stream).__name__`.
-        std::stringstream error;
-        error << "Failed to convert the stream object into a CUDA stream.";
-        throw nanobind::type_error(error.str().c_str());
-    }
-}
-#endif
-} // namespace
 
 void
 register_communication_object(nanobind::module_& m)

--- a/test/bindings/python/CMakeLists.txt
+++ b/test/bindings/python/CMakeLists.txt
@@ -54,7 +54,8 @@ add_dependencies(pyghex_tests pyghex_files)
 add_dependencies(pyghex_tests setup_test_env)
 
 copy_files(TARGET pyghex_tests DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/fixtures FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/context.py)
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/context.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/cuda_stream.py)
 copy_files(TARGET pyghex_tests DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/conftest.py)
 

--- a/test/bindings/python/fixtures/cuda_stream.py
+++ b/test/bindings/python/fixtures/cuda_stream.py
@@ -23,9 +23,7 @@ class CUDAStreamProtocolMock:
         return 0, self.stream.ptr
 
 
-# Exposes `.ptr` and nothing else, the way cupy streams did before they grew
-# `__cuda_stream__`. Recent cupy streams implement the protocol, so `extract_cuda_stream`
-# resolves them there and its `.ptr` fallback would otherwise never be reached.
+# Exposes `.ptr` and nothing else, the way cupy streams do up to cupy 13.
 class PtrOnlyStreamMock:
     def __init__(self, stream):
         self.ptr = stream.ptr
@@ -35,6 +33,11 @@ class PtrOnlyStreamMock:
 # they cover all three branches of `extract_cuda_stream`: "default" the `nullptr` one,
 # "protocol" the `__cuda_stream__` one, "ptr" the `.ptr` one. "null" and "non_blocking"
 # are there for the stream semantics rather than the conversion.
+#
+# Both mocks are needed because a real cupy stream only reaches one branch, and which
+# one depends on the installed version: cupy 13 streams expose `.ptr` alone, cupy 14
+# streams also implement `__cuda_stream__` and so are resolved there instead. Without
+# the mocks, whichever branch the installed cupy does not exercise goes untested.
 STREAM_KINDS = (None, "default", "null", "non_blocking", "protocol", "ptr")
 
 

--- a/test/bindings/python/fixtures/cuda_stream.py
+++ b/test/bindings/python/fixtures/cuda_stream.py
@@ -1,0 +1,40 @@
+#
+# ghex-org
+#
+# Copyright (c) 2014-2023, ETH Zurich
+# All rights reserved.
+#
+# Please, refer to the LICENSE file in the root directory.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+
+# Implements Nvidia's CUDA stream protocol, see
+# https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
+class CUDAStreamProtocolMock:
+    def __init__(self, stream):
+        self.stream = stream
+
+    def __cuda_stream__(self):
+        return 0, self.stream.ptr
+
+
+# `None` selects a plain exchange; the others select a scheduled exchange and between
+# them cover all three branches of `extract_cuda_stream`: "default" the `nullptr` one,
+# "null" and "non_blocking" the `.ptr` one, "protocol" the `__cuda_stream__` one.
+STREAM_KINDS = (None, "default", "null", "non_blocking", "protocol")
+
+
+def make_stream(kind):
+    # returns the object handed to ghex and the cupy stream it denotes; the two differ
+    # for the kinds that do not pass a cupy stream through directly
+    if kind == "default":
+        return None, cp.cuda.Stream.null
+    stream = cp.cuda.Stream(null=True) if kind == "null" else cp.cuda.Stream(non_blocking=True)
+    if kind == "protocol":
+        return CUDAStreamProtocolMock(stream), stream
+    return stream, stream

--- a/test/bindings/python/fixtures/cuda_stream.py
+++ b/test/bindings/python/fixtures/cuda_stream.py
@@ -23,10 +23,19 @@ class CUDAStreamProtocolMock:
         return 0, self.stream.ptr
 
 
-# `None` selects a plain exchange; the others select a scheduled exchange and between
-# them cover all three branches of `extract_cuda_stream`: "default" the `nullptr` one,
-# "null" and "non_blocking" the `.ptr` one, "protocol" the `__cuda_stream__` one.
-STREAM_KINDS = (None, "default", "null", "non_blocking", "protocol")
+# Exposes `.ptr` and nothing else, the way cupy streams did before they grew
+# `__cuda_stream__`. Recent cupy streams implement the protocol, so `extract_cuda_stream`
+# resolves them there and its `.ptr` fallback would otherwise never be reached.
+class PtrOnlyStreamMock:
+    def __init__(self, stream):
+        self.ptr = stream.ptr
+
+
+# `None` selects a plain exchange; the others select a scheduled exchange. Between them
+# they cover all three branches of `extract_cuda_stream`: "default" the `nullptr` one,
+# "protocol" the `__cuda_stream__` one, "ptr" the `.ptr` one. "null" and "non_blocking"
+# are there for the stream semantics rather than the conversion.
+STREAM_KINDS = (None, "default", "null", "non_blocking", "protocol", "ptr")
 
 
 def make_stream(kind):
@@ -37,4 +46,6 @@ def make_stream(kind):
     stream = cp.cuda.Stream(null=True) if kind == "null" else cp.cuda.Stream(non_blocking=True)
     if kind == "protocol":
         return CUDAStreamProtocolMock(stream), stream
+    if kind == "ptr":
+        return PtrOnlyStreamMock(stream), stream
     return stream, stream

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -12,9 +12,14 @@ import pytest
 
 from mpi4py import MPI
 
-# import cupy as cp
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
 
+import ghex
 from ghex.context import make_context
+from ghex.util import Architecture
 from ghex.structured.cartesian_sets import IndexSpace
 from ghex.structured.regular import (
     make_communication_object,
@@ -35,9 +40,33 @@ halos_per_dim = ((2, 1), (1, 2), (1, 1))
 
 
 @pytest.mark.mpi
+@pytest.mark.parametrize("gpu_and_stream", (
+    (False, None),
+    (True, None),
+    (True, {"null": True}),
+    (True, {"non_blocking": True}),
+))
 @pytest.mark.parametrize("periodic", [True, False])
 @pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_pattern(capsys, ndim, periodic):
+def test_pattern(capsys, ndim, periodic, gpu_and_stream):
+    gpu, stream_args = gpu_and_stream
+    if gpu:
+        if cp is None:
+            pytest.skip("`CuPy` is not installed.")
+        if not cp.is_available():
+            pytest.skip("`CuPy` is installed but no GPU could be found.")
+        if not ghex.__config__["gpu"]:
+            pytest.skip("`GHEX` was not compiled with GPU support.")
+        xp = cp
+        arch = Architecture.GPU
+    else:
+        xp = np
+        arch = Architecture.CPU
+    # `stream_args is None` selects a plain exchange, with the cupy arrays living
+    # on the cupy default stream; otherwise a scheduled exchange is run on the
+    # requested stream (the null/default stream or a non-blocking one).
+    cuda_stream = cp.cuda.Stream(**stream_args) if stream_args else None
+
     mpi_comm = MPI.COMM_WORLD
 
     # decompose all `ndim` dimensions over the ranks
@@ -80,18 +109,34 @@ def test_pattern(capsys, ndim, periodic):
     co = make_communication_object(ctx)
 
     def make_field():
-        field_1 = np.zeros(
-            memory_local_grid.bounds.shape, dtype=np.float64, order="F"
-        )  # todo: , order='F'
-        # field_1 = cp.zeros(memory_local_grid.bounds.shape, dtype=np.float64, order='F')
+        field_1 = xp.zeros(memory_local_grid.bounds.shape, dtype=np.float64, order="F")
         gfield_1 = make_field_descriptor(
             domain_desc,
             field_1,
             memory_local_grid.subset["definition"][(0,) * ndim],
             memory_local_grid.bounds.shape,
-        )  # ,
-        # arch=architecture.CPU)
+            arch=arch,
+        )
         return field_1, gfield_1
+
+    def exchange(buffer_infos):
+        if cuda_stream is None:
+            if gpu:
+                cp.cuda.Device().synchronize()
+            res = co.exchange(buffer_infos)
+            res.wait()
+        else:
+            # The fields were initialized on the cupy default stream. Unless we are
+            # scheduling on that same (null) stream, make `cuda_stream` wait for
+            # them so they are not packed prematurely.
+            if not stream_args.get("null"):
+                cuda_stream.wait_event(cp.cuda.get_current_stream().record())
+            res = co.schedule_exchange(cuda_stream, buffer_infos)
+            assert not co.has_scheduled_exchange()
+            res.schedule_wait(cuda_stream)
+            assert co.has_scheduled_exchange()
+            res.wait()
+            assert not co.has_scheduled_exchange()
 
     # one field per dimension, each storing the owner's coordinate in that dimension
     fields = []
@@ -103,17 +148,18 @@ def test_pattern(capsys, ndim, periodic):
     for p_dim, p_coord_l in enumerate(p_coord):
         fields[p_dim][...] = p_coord_l
 
-    res = co.exchange([pattern(gfield) for gfield in gfields])
-    res.wait()
+    exchange([pattern(gfield) for gfield in gfields])
 
     rank_field, grank_field = make_field()
     rank_field[...] = ctx.rank()
-    # cp.cuda.Device(0).synchronize()
-    res = co.exchange(
+    exchange(
         [pattern(grank_field)]
     )  # arch, dtype. exchange of fields living on cpu+gpu possible
-    res.wait()
-    # cp.cuda.Device(0).synchronize()
+
+    # copy the results back to the host for checking
+    if gpu:
+        fields = [cp.asnumpy(field) for field in fields]
+        rank_field = cp.asnumpy(rank_field)
 
     with capsys.disabled():
         print("post_ex:")

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -18,6 +18,7 @@ except ImportError:
     cp = None
 
 import ghex
+from fixtures.cuda_stream import STREAM_KINDS, make_stream
 from ghex.context import make_context
 from ghex.util import Architecture
 from ghex.structured.cartesian_sets import IndexSpace
@@ -40,16 +41,13 @@ halos_per_dim = ((2, 1), (1, 2), (1, 1))
 
 
 @pytest.mark.mpi
-@pytest.mark.parametrize("gpu_and_stream", (
-    (False, None),
-    (True, None),
-    (True, {"null": True}),
-    (True, {"non_blocking": True}),
-))
+@pytest.mark.parametrize(
+    "gpu_and_stream", [(False, None)] + [(True, kind) for kind in STREAM_KINDS]
+)
 @pytest.mark.parametrize("periodic", [True, False])
 @pytest.mark.parametrize("ndim", [1, 2, 3])
 def test_pattern(capsys, ndim, periodic, gpu_and_stream):
-    gpu, stream_args = gpu_and_stream
+    gpu, stream_kind = gpu_and_stream
     if gpu:
         if cp is None:
             pytest.skip("`CuPy` is not installed.")
@@ -62,10 +60,9 @@ def test_pattern(capsys, ndim, periodic, gpu_and_stream):
     else:
         xp = np
         arch = Architecture.CPU
-    # `stream_args is None` selects a plain exchange, with the cupy arrays living
-    # on the cupy default stream; otherwise a scheduled exchange is run on the
-    # requested stream (the null/default stream or a non-blocking one).
-    cuda_stream = cp.cuda.Stream(**stream_args) if stream_args else None
+    # `stream_kind is None` selects a plain exchange, with the cupy arrays living on the
+    # cupy default stream; otherwise a scheduled exchange is run on the requested stream.
+    ghex_stream, cuda_stream = (None, None) if stream_kind is None else make_stream(stream_kind)
 
     mpi_comm = MPI.COMM_WORLD
 
@@ -119,24 +116,31 @@ def test_pattern(capsys, ndim, periodic, gpu_and_stream):
         )
         return field_1, gfield_1
 
-    def exchange(buffer_infos):
-        if cuda_stream is None:
+    def exchange(buffer_infos, arrays):
+        if stream_kind is None:
             if gpu:
                 cp.cuda.Device().synchronize()
             res = co.exchange(buffer_infos)
             res.wait()
-        else:
-            # The fields were initialized on the cupy default stream. Unless we are
-            # scheduling on that same (null) stream, make `cuda_stream` wait for
-            # them so they are not packed prematurely.
-            if not stream_args.get("null"):
-                cuda_stream.wait_event(cp.cuda.get_current_stream().record())
-            res = co.schedule_exchange(cuda_stream, buffer_infos)
-            assert not co.has_scheduled_exchange()
-            res.schedule_wait(cuda_stream)
-            assert co.has_scheduled_exchange()
-            res.wait()
-            assert not co.has_scheduled_exchange()
+            return [cp.asnumpy(a, order="F") for a in arrays] if gpu else list(arrays)
+
+        # The fields were initialized on the cupy default stream. Unless we are
+        # scheduling on that same (null) stream, make `cuda_stream` wait for
+        # them so they are not packed prematurely.
+        if cuda_stream.ptr != 0:
+            cuda_stream.wait_event(cp.cuda.get_current_stream().record())
+        res = co.schedule_exchange(ghex_stream, buffer_infos)
+        assert not co.has_scheduled_exchange()
+        res.schedule_wait(ghex_stream)
+        assert co.has_scheduled_exchange()
+        # Read back synchronizing on the scheduled stream only, before `wait()`: this
+        # is what checks that the unpack is ordered against the stream, rather than
+        # merely made visible by the host-blocking sync inside `wait()`.
+        host = [cp.asnumpy(a, order="F", stream=cuda_stream, blocking=True) for a in arrays]
+        assert co.has_scheduled_exchange()
+        res.wait()
+        assert not co.has_scheduled_exchange()
+        return host
 
     # one field per dimension, each storing the owner's coordinate in that dimension
     fields = []
@@ -148,18 +152,12 @@ def test_pattern(capsys, ndim, periodic, gpu_and_stream):
     for p_dim, p_coord_l in enumerate(p_coord):
         fields[p_dim][...] = p_coord_l
 
-    exchange([pattern(gfield) for gfield in gfields])
+    fields = exchange([pattern(gfield) for gfield in gfields], fields)
 
     rank_field, grank_field = make_field()
     rank_field[...] = ctx.rank()
-    exchange(
-        [pattern(grank_field)]
-    )  # arch, dtype. exchange of fields living on cpu+gpu possible
-
-    # copy the results back to the host for checking
-    if gpu:
-        fields = [cp.asnumpy(field) for field in fields]
-        rank_field = cp.asnumpy(rank_field)
+    # arch, dtype. exchange of fields living on cpu+gpu possible
+    (rank_field,) = exchange([pattern(grank_field)], [rank_field])
 
     with capsys.disabled():
         print("post_ex:")

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -122,7 +122,7 @@ def test_pattern(capsys, ndim, periodic, gpu_and_stream):
                     cp.cuda.Device().synchronize()
                 res = co.exchange(buffer_infos)
                 res.wait()
-                return [cp.asnumpy(a, order="F") for a in arrays] if gpu else list(arrays)
+                return [cp.asnumpy(a) for a in arrays] if gpu else list(arrays)
 
             # The fields were initialized on the cupy default stream. Unless we are
             # scheduling on that same (null) stream, make `cuda_stream` wait for
@@ -136,7 +136,7 @@ def test_pattern(capsys, ndim, periodic, gpu_and_stream):
             # Read back synchronizing on the scheduled stream only, before `wait()`:
             # this is what checks that the unpack is ordered against the stream,
             # rather than merely made visible by the host-blocking sync in `wait()`.
-            host = [cp.asnumpy(a, order="F", stream=cuda_stream, blocking=True) for a in arrays]
+            host = [cp.asnumpy(a, stream=cuda_stream, blocking=True) for a in arrays]
             assert co.has_scheduled_exchange()
             res.wait()
             assert not co.has_scheduled_exchange()

--- a/test/bindings/python/test_unstructured_domain_descriptor.py
+++ b/test/bindings/python/test_unstructured_domain_descriptor.py
@@ -12,22 +12,11 @@ import numpy as np
 
 try:
     import cupy as cp
-
-    # Mock to implement CUDA's Stream protocol: https://nvidia.github.io/cuda-python/cuda-core/latest/interoperability.html#cuda-stream-protocol
-    class CUDAStreamProtocolMock:
-        def __init__(self, *args, **kwargs):
-            self.cupy_stream = cp.cuda.Stream(*args, **kwargs)
-
-        def __cuda_stream__(self):
-            return 0, self.cupy_stream.ptr
-
-    STREAM_TYPES_TO_TEST = [None, cp.cuda.Stream, CUDAStreamProtocolMock]
-
 except ImportError:
     cp = None
-    STREAM_TYPES_TO_TEST = [None]  # Must be at least one element.
 
 import ghex
+from ghex.context import make_context
 from ghex.unstructured import make_communication_object
 from ghex.unstructured import DomainDescriptor
 from ghex.unstructured import HaloGenerator
@@ -224,15 +213,28 @@ domains = {
 
 LEVELS = 2
 
-
 @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int32, np.int64])
-@pytest.mark.parametrize("on_gpu", [True, False])
+@pytest.mark.parametrize("gpu_and_stream", (
+    (False, None),
+    (True, None),
+    (True, {"null": True}),
+    (True, {"non_blocking": True}),
+))
 @pytest.mark.mpi
-def test_domain_descriptor(on_gpu, capsys, mpi_cart_comm, cart_context, dtype):
-    # Does not uses streams.
+def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
+    gpu, stream_args = gpu_and_stream
+    if gpu:
+        if cp is None:
+            pytest.skip("`CuPy` is not installed.")
+        if not cp.is_available():
+            pytest.skip("`CuPy` is installed but no GPU could be found.")
+        if not ghex.__config__["gpu"]:
+            pytest.skip("`GHEX` was not compiled with GPU support.")
 
-    if on_gpu and cp is None:
-        pytest.skip(reason="`CuPy` is not installed.")
+    # `stream_args is None` selects a plain exchange, with the cupy arrays living
+    # on the cupy default stream; otherwise a scheduled exchange is run on the
+    # requested stream (the null/default stream or a non-blocking one).
+    cuda_stream = cp.cuda.Stream(**stream_args) if stream_args else None
 
     ctx = cart_context
     assert ctx.size() == 4
@@ -247,7 +249,9 @@ def test_domain_descriptor(on_gpu, capsys, mpi_cart_comm, cart_context, dtype):
 
     def make_field(order):
         # Creation is always on host.
-        data = np.zeros([len(domains[ctx.rank()]["all"]), LEVELS], dtype=dtype, order=order)
+        data = np.zeros(
+            [len(domains[ctx.rank()]["all"]), LEVELS], dtype=dtype, order=order
+        )
         inner_set = set(domains[ctx.rank()]["inner"])
         all_list = domains[ctx.rank()]["all"]
         for x in range(len(all_list)):
@@ -258,14 +262,14 @@ def test_domain_descriptor(on_gpu, capsys, mpi_cart_comm, cart_context, dtype):
                 else:
                     data[x, l] = -1
 
-        if on_gpu:
+        if gpu:
             data = cp.array(data, order=order)
 
         field = make_field_descriptor(domain_desc, data)
         return data, field
 
     def check_field(data, order):
-        if on_gpu:
+        if gpu:
             # NOTE: Without the explicit order it fails sometimes.
             data = cp.asnumpy(data, order=order)
         inner_set = set(domains[ctx.rank()]["inner"])
@@ -276,11 +280,25 @@ def test_domain_descriptor(on_gpu, capsys, mpi_cart_comm, cart_context, dtype):
                 if gid in inner_set:
                     assert data[x, l] == ctx.rank() * 1000 + 10 * gid + l
                 else:
-                    assert (data[x, l] - 1000 * int((data[x, l]) / 1000)) == 10 * gid + l
+                    assert (
+                        data[x, l] - 1000 * int((data[x, l]) / 1000)
+                    ) == 10 * gid + l
 
-        # TODO: Find out if there is a side effect that makes it important to keep them.
-        # field = make_field_descriptor(domain_desc, data)
-        # return data, field
+    def exchange(buffer_infos):
+        if cuda_stream is None:
+            if gpu:
+                cp.cuda.Device().synchronize()
+            handle = co.exchange(buffer_infos)
+            handle.wait()
+        else:
+            if not stream_args.get("null"):
+                cuda_stream.wait_event(cp.cuda.get_current_stream().record())
+            handle = co.schedule_exchange(cuda_stream, buffer_infos)
+            assert not co.has_scheduled_exchange()
+            handle.schedule_wait(cuda_stream)
+            assert co.has_scheduled_exchange()
+            handle.wait()
+            assert not co.has_scheduled_exchange()
 
     halo_gen = HaloGenerator.from_gids(domains[ctx.rank()]["outer"])
     pattern = make_pattern(ctx, halo_gen, [domain_desc])
@@ -289,89 +307,7 @@ def test_domain_descriptor(on_gpu, capsys, mpi_cart_comm, cart_context, dtype):
     d1, f1 = make_field("C")
     d2, f2 = make_field("F")
 
-    handle = co.exchange([pattern(f1), pattern(f2)])
-    handle.wait()
+    exchange([pattern(f1), pattern(f2)])
 
     check_field(d1, "C")
     check_field(d2, "F")
-
-
-@pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int32, np.int64])
-@pytest.mark.parametrize("on_gpu", [True, False])
-@pytest.mark.parametrize("stream_type", STREAM_TYPES_TO_TEST)
-@pytest.mark.mpi
-def test_domain_descriptor_async(on_gpu, stream_type, capsys, mpi_cart_comm, cart_context, dtype):
-
-    if on_gpu:
-        if cp is None:
-            pytest.skip(reason="`CuPy` is not installed.")
-        if not cp.is_available():
-            pytest.skip(reason="`CuPy` is installed but no GPU could be found.")
-    if not ghex.__config__["gpu"]:
-        pytest.skip(
-            reason="Skipping `schedule_exchange()` tests because `GHEX` was not compiled with GPU support"
-        )
-
-    ctx = cart_context
-    assert ctx.size() == 4
-
-    domain_desc = DomainDescriptor(
-        ctx.rank(), domains[ctx.rank()]["all"], domains[ctx.rank()]["outer_lids"]
-    )
-
-    assert domain_desc.domain_id() == ctx.rank()
-    assert domain_desc.size() == len(domains[ctx.rank()]["all"])
-    assert domain_desc.inner_size() == len(domains[ctx.rank()]["inner"])
-
-    def make_field(order):
-        data = np.zeros([len(domains[ctx.rank()]["all"]), LEVELS], dtype=dtype, order=order)
-        inner_set = set(domains[ctx.rank()]["inner"])
-        all_list = domains[ctx.rank()]["all"]
-        for x in range(len(all_list)):
-            gid = all_list[x]
-            for l in range(LEVELS):
-                if gid in inner_set:
-                    data[x, l] = ctx.rank() * 1000 + 10 * gid + l
-                else:
-                    data[x, l] = -1
-        if on_gpu:
-            data = cp.array(data, order=order)
-
-        field = make_field_descriptor(domain_desc, data)
-        return data, field
-
-    def check_field(data, order, stream):
-        inner_set = set(domains[ctx.rank()]["inner"])
-        all_list = domains[ctx.rank()]["all"]
-        if on_gpu:
-            # NOTE: Without the explicit order it fails sometimes.
-            data = cp.asnumpy(data, order=order, stream=stream, blocking=True)
-
-        for x in range(len(all_list)):
-            gid = all_list[x]
-            for l in range(LEVELS):
-                if gid in inner_set:
-                    assert data[x, l] == ctx.rank() * 1000 + 10 * gid + l
-                else:
-                    assert (data[x, l] - 1000 * int((data[x, l]) / 1000)) == 10 * gid + l
-
-    halo_gen = HaloGenerator.from_gids(domains[ctx.rank()]["outer"])
-    pattern = make_pattern(ctx, halo_gen, [domain_desc])
-    co = make_communication_object(ctx)
-
-    d1, f1 = make_field("C")
-    d2, f2 = make_field("F")
-
-    stream = None if stream_type is None else stream_type(non_blocking=True)
-    handle = co.schedule_exchange(stream, [pattern(f1), pattern(f2)])
-    assert not co.has_scheduled_exchange()
-
-    handle.schedule_wait(stream)
-    assert co.has_scheduled_exchange()
-
-    check_field(d1, "C", stream)
-    check_field(d2, "F", stream)
-    assert co.has_scheduled_exchange()
-
-    handle.wait()
-    assert not co.has_scheduled_exchange()

--- a/test/bindings/python/test_unstructured_domain_descriptor.py
+++ b/test/bindings/python/test_unstructured_domain_descriptor.py
@@ -16,7 +16,7 @@ except ImportError:
     cp = None
 
 import ghex
-from ghex.context import make_context
+from fixtures.cuda_stream import STREAM_KINDS, make_stream
 from ghex.unstructured import make_communication_object
 from ghex.unstructured import DomainDescriptor
 from ghex.unstructured import HaloGenerator
@@ -214,15 +214,12 @@ domains = {
 LEVELS = 2
 
 @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int32, np.int64])
-@pytest.mark.parametrize("gpu_and_stream", (
-    (False, None),
-    (True, None),
-    (True, {"null": True}),
-    (True, {"non_blocking": True}),
-))
+@pytest.mark.parametrize(
+    "gpu_and_stream", [(False, None)] + [(True, kind) for kind in STREAM_KINDS]
+)
 @pytest.mark.mpi
-def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
-    gpu, stream_args = gpu_and_stream
+def test_domain_descriptor(gpu_and_stream, cart_context, dtype):
+    gpu, stream_kind = gpu_and_stream
     if gpu:
         if cp is None:
             pytest.skip("`CuPy` is not installed.")
@@ -231,10 +228,9 @@ def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
         if not ghex.__config__["gpu"]:
             pytest.skip("`GHEX` was not compiled with GPU support.")
 
-    # `stream_args is None` selects a plain exchange, with the cupy arrays living
-    # on the cupy default stream; otherwise a scheduled exchange is run on the
-    # requested stream (the null/default stream or a non-blocking one).
-    cuda_stream = cp.cuda.Stream(**stream_args) if stream_args else None
+    # `stream_kind is None` selects a plain exchange, with the cupy arrays living on the
+    # cupy default stream; otherwise a scheduled exchange is run on the requested stream.
+    ghex_stream, cuda_stream = (None, None) if stream_kind is None else make_stream(stream_kind)
 
     ctx = cart_context
     assert ctx.size() == 4
@@ -268,10 +264,7 @@ def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
         field = make_field_descriptor(domain_desc, data)
         return data, field
 
-    def check_field(data, order):
-        if gpu:
-            # NOTE: Without the explicit order it fails sometimes.
-            data = cp.asnumpy(data, order=order)
+    def check_field(data):
         inner_set = set(domains[ctx.rank()]["inner"])
         all_list = domains[ctx.rank()]["all"]
         for x in range(len(all_list)):
@@ -284,21 +277,29 @@ def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
                         data[x, l] - 1000 * int((data[x, l]) / 1000)
                     ) == 10 * gid + l
 
-    def exchange(buffer_infos):
-        if cuda_stream is None:
+    def exchange(buffer_infos, arrays):
+        # NOTE: the explicit order is needed, without it it fails sometimes.
+        if stream_kind is None:
             if gpu:
                 cp.cuda.Device().synchronize()
             handle = co.exchange(buffer_infos)
             handle.wait()
-        else:
-            if not stream_args.get("null"):
-                cuda_stream.wait_event(cp.cuda.get_current_stream().record())
-            handle = co.schedule_exchange(cuda_stream, buffer_infos)
-            assert not co.has_scheduled_exchange()
-            handle.schedule_wait(cuda_stream)
-            assert co.has_scheduled_exchange()
-            handle.wait()
-            assert not co.has_scheduled_exchange()
+            return [cp.asnumpy(a, order=o) for a, o in arrays] if gpu else [a for a, _ in arrays]
+
+        if cuda_stream.ptr != 0:
+            cuda_stream.wait_event(cp.cuda.get_current_stream().record())
+        handle = co.schedule_exchange(ghex_stream, buffer_infos)
+        assert not co.has_scheduled_exchange()
+        handle.schedule_wait(ghex_stream)
+        assert co.has_scheduled_exchange()
+        # Read back synchronizing on the scheduled stream only, before `wait()`: this
+        # is what checks that the unpack is ordered against the stream, rather than
+        # merely made visible by the host-blocking sync inside `wait()`.
+        host = [cp.asnumpy(a, order=o, stream=cuda_stream, blocking=True) for a, o in arrays]
+        assert co.has_scheduled_exchange()
+        handle.wait()
+        assert not co.has_scheduled_exchange()
+        return host
 
     halo_gen = HaloGenerator.from_gids(domains[ctx.rank()]["outer"])
     pattern = make_pattern(ctx, halo_gen, [domain_desc])
@@ -307,7 +308,5 @@ def test_domain_descriptor(gpu_and_stream, capsys, cart_context, dtype):
     d1, f1 = make_field("C")
     d2, f2 = make_field("F")
 
-    exchange([pattern(f1), pattern(f2)])
-
-    check_field(d1, "C")
-    check_field(d2, "F")
+    for data in exchange([pattern(f1), pattern(f2)], [(d1, "C"), (d2, "F")]):
+        check_field(data)

--- a/test/bindings/python/test_unstructured_domain_descriptor.py
+++ b/test/bindings/python/test_unstructured_domain_descriptor.py
@@ -278,13 +278,12 @@ def test_domain_descriptor(gpu_and_stream, cart_context, dtype):
                     ) == 10 * gid + l
 
     def exchange(buffer_infos, arrays):
-        # NOTE: the explicit order is needed, without it it fails sometimes.
         if stream_kind is None:
             if gpu:
                 cp.cuda.Device().synchronize()
             handle = co.exchange(buffer_infos)
             handle.wait()
-            return [cp.asnumpy(a, order=o) for a, o in arrays] if gpu else [a for a, _ in arrays]
+            return [cp.asnumpy(a) for a in arrays] if gpu else list(arrays)
 
         if cuda_stream.ptr != 0:
             cuda_stream.wait_event(cp.cuda.get_current_stream().record())
@@ -295,7 +294,7 @@ def test_domain_descriptor(gpu_and_stream, cart_context, dtype):
         # Read back synchronizing on the scheduled stream only, before `wait()`: this
         # is what checks that the unpack is ordered against the stream, rather than
         # merely made visible by the host-blocking sync inside `wait()`.
-        host = [cp.asnumpy(a, order=o, stream=cuda_stream, blocking=True) for a, o in arrays]
+        host = [cp.asnumpy(a, stream=cuda_stream, blocking=True) for a in arrays]
         assert co.has_scheduled_exchange()
         handle.wait()
         assert not co.has_scheduled_exchange()
@@ -308,5 +307,5 @@ def test_domain_descriptor(gpu_and_stream, cart_context, dtype):
     d1, f1 = make_field("C")
     d2, f2 = make_field("F")
 
-    for data in exchange([pattern(f1), pattern(f2)], [(d1, "C"), (d2, "F")]):
+    for data in exchange([pattern(f1), pattern(f2)], [d1, d2]):
         check_field(data)


### PR DESCRIPTION
Share extract_cuda_stream via cuda_stream.hpp; parametrize the structured and unstructured exchange tests over gpu memory and stream (plain vs scheduled).