### PR TITLE
Fix unstructured GPU exchange silently corrupting halos with more than blockDim.y * 65535 indices

### DIFF
--- a/include/ghex/unstructured/user_concepts.hpp
+++ b/include/ghex/unstructured/user_concepts.hpp
@@ -463,8 +463,11 @@ pack_kernel_levels_first(const T* values, const std::size_t local_indices_size,
     const std::size_t* local_indices, const std::size_t levels, T* buffer,
     const std::size_t index_stride, const std::size_t buffer_index_stride)
 {
-    const std::size_t level = threadIdx.x + (blockIdx.x * blockDim.x);
-    const std::size_t idx = threadIdx.y + (blockIdx.y * blockDim.y);
+    // the index blocks are mapped to gridDim.x (levels to gridDim.y) because the
+    // number of indices may exceed the gridDim.y limit of 65535 blocks; the
+    // thread mapping keeps levels on threadIdx.x for coalesced accesses
+    const std::size_t level = threadIdx.x + (blockIdx.y * blockDim.x);
+    const std::size_t idx = threadIdx.y + (blockIdx.x * blockDim.y);
 
     if (idx < local_indices_size && level < levels)
     {
@@ -496,8 +499,9 @@ unpack_kernel_levels_first(const T* buffer, const std::size_t local_indices_size
 
     const std::size_t index_stride, const std::size_t buffer_index_stride)
 {
-    const std::size_t level = threadIdx.x + (blockIdx.x * blockDim.x);
-    const std::size_t idx = threadIdx.y + (blockIdx.y * blockDim.y);
+    // see pack_kernel_levels_first for the block mapping
+    const std::size_t level = threadIdx.x + (blockIdx.y * blockDim.x);
+    const std::size_t idx = threadIdx.y + (blockIdx.x * blockDim.y);
 
     if (idx < local_indices_size && level < levels)
     {
@@ -596,12 +600,13 @@ class data_descriptor<gpu, DomainId, Idx, T>
                     std::ceil(static_cast<double>(is.local_indices().size()) /
                               GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y));
 
-                const dim3 blocks(blocks_levels, blocks_indices);
+                const dim3 blocks(blocks_indices, blocks_levels);
 
                 pack_kernel_levels_first<value_type><<<blocks, threads_per_block, 0,
                     *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(m_values,
                     is.local_indices().size(), is.local_indices().data(), m_levels, buffer,
                     m_index_stride, m_levels);
+                GHEX_CHECK_CUDA_RESULT(cudaGetLastError());
             }
             else
             {
@@ -618,6 +623,7 @@ class data_descriptor<gpu, DomainId, Idx, T>
                     *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(m_values,
                     is.local_indices().size(), is.local_indices().data(), m_levels, buffer,
                     m_level_stride, is.local_indices().size());
+                GHEX_CHECK_CUDA_RESULT(cudaGetLastError());
             }
         }
     }
@@ -639,12 +645,13 @@ class data_descriptor<gpu, DomainId, Idx, T>
                     std::ceil(static_cast<double>(is.local_indices().size()) /
                               GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y));
 
-                const dim3 blocks(blocks_levels, blocks_indices);
+                const dim3 blocks(blocks_indices, blocks_levels);
 
                 unpack_kernel_levels_first<value_type><<<blocks, threads_per_block, 0,
                     *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(buffer,
                     is.local_indices().size(), is.local_indices().data(), m_levels, m_values,
                     m_index_stride, m_levels);
+                GHEX_CHECK_CUDA_RESULT(cudaGetLastError());
             }
             else
             {
@@ -661,6 +668,7 @@ class data_descriptor<gpu, DomainId, Idx, T>
                     *(reinterpret_cast<cudaStream_t*>(stream_ptr))>>>(buffer,
                     is.local_indices().size(), is.local_indices().data(), m_levels, m_values,
                     m_level_stride, is.local_indices().size());
+                GHEX_CHECK_CUDA_RESULT(cudaGetLastError());
             }
         }
     }

--- a/test/unstructured/CMakeLists.txt
+++ b/test/unstructured/CMakeLists.txt
@@ -3,3 +3,6 @@ ghex_compile_test(user_concepts)
 ghex_reg_parallel_test(user_concepts 4 false)
 ghex_reg_parallel_test(user_concepts 2 true)
 
+ghex_compile_test(large_halo)
+ghex_reg_parallel_test(large_halo 2 false)
+

--- a/test/unstructured/test_large_halo.cpp
+++ b/test/unstructured/test_large_halo.cpp
@@ -1,0 +1,97 @@
+/*
+ * ghex-org
+ *
+ * Copyright (c) 2014-2026, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// The unstructured GPU pack/unpack kernels place ceil(num_indices / blockDim.y)
+// in gridDim.y, which CUDA limits to 65535. A halo with more than
+// blockDim.y * 65535 indices per neighbour makes the kernel launch fail with an
+// invalid configuration; the missing launch-error check lets the exchange
+// complete silently with the halo left untouched.
+
+#include <gtest/gtest.h>
+#include "../mpi_runner/mpi_test_fixture.hpp"
+
+#include <ghex/config.hpp>
+#include <ghex/unstructured/pattern.hpp>
+#include <ghex/unstructured/user_concepts.hpp>
+#include <ghex/communication_object.hpp>
+#include "../util/memory.hpp"
+
+#include <numeric>
+#include <set>
+#include <vector>
+
+using domain_id_type = int;
+using global_index_type = int;
+using domain_descriptor_type =
+    ghex::unstructured::domain_descriptor<domain_id_type, global_index_type>;
+using halo_generator_type = ghex::unstructured::halo_generator<domain_id_type, global_index_type>;
+using grid_type = ghex::unstructured::grid;
+
+#ifdef GHEX_CUDACC
+
+using data_descriptor_gpu_type =
+    ghex::unstructured::data_descriptor<ghex::gpu, domain_id_type, global_index_type, int>;
+
+namespace
+{
+// larger than GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y * 65535
+constexpr int halo_size = 600000;
+constexpr int inner_size = halo_size;
+
+// Each rank owns gids [rank*inner_size, (rank+1)*inner_size); its halo is the
+// first halo_size gids of the other rank, stored after the inner elements.
+domain_descriptor_type
+make_two_rank_domain(int rank)
+{
+    const int                      other = 1 - rank;
+    std::vector<global_index_type> gids(inner_size + halo_size);
+    std::iota(gids.begin(), gids.begin() + inner_size, rank * inner_size);
+    std::iota(gids.begin() + inner_size, gids.end(), other * inner_size);
+    std::vector<domain_descriptor_type::local_index_type> halo_lids(halo_size);
+    std::iota(halo_lids.begin(), halo_lids.end(), inner_size);
+    return {rank, gids.begin(), gids.end(), halo_lids.begin(), halo_lids.end()};
+}
+} // namespace
+
+TEST_F(mpi_test_fixture, large_halo)
+{
+    if (world_size != 2) GTEST_SKIP() << "test requires exactly 2 ranks";
+
+    ghex::context ctxt{MPI_COMM_WORLD, false};
+
+    std::vector<domain_descriptor_type> local_domains{make_two_rank_domain(ctxt.rank())};
+    const auto&                         d = local_domains[0];
+
+    std::set<global_index_type> halo_set(d.outer_gids().begin(), d.outer_gids().end());
+    halo_generator_type         hg{halo_set.begin(), halo_set.end()};
+
+    auto patterns = ghex::make_pattern<grid_type>(ctxt, hg, local_domains);
+    auto co = ghex::make_communication_object<decltype(patterns)>(ctxt);
+
+    ghex::test::util::memory<int> field(d.size(), 0);
+    for (unsigned int lid = 0; lid < d.size(); ++lid)
+        field[lid] = lid < inner_size ? static_cast<int>(d.global_index(lid).value()) + 1 : 0;
+    field.clone_to_device();
+    data_descriptor_gpu_type data{d, field.device_data(), 1, true, 0, 0};
+
+    co.exchange(patterns(data)).wait();
+
+    field.clone_to_host();
+    int num_bad = 0;
+    for (unsigned int lid = inner_size; lid < d.size(); ++lid)
+        if (field[lid] != static_cast<int>(d.global_index(lid).value()) + 1) ++num_bad;
+    EXPECT_EQ(num_bad, 0) << "halo elements were not exchanged correctly";
+}
+
+#else // GHEX_CUDACC
+
+TEST_F(mpi_test_fixture, large_halo) { GTEST_SKIP() << "GPU-only test"; }
+
+#endif

--- a/test/unstructured/test_large_halo.cpp
+++ b/test/unstructured/test_large_halo.cpp
@@ -8,11 +8,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-// The unstructured GPU pack/unpack kernels place ceil(num_indices / blockDim.y)
-// in gridDim.y, which CUDA limits to 65535. A halo with more than
-// blockDim.y * 65535 indices per neighbour makes the kernel launch fail with an
-// invalid configuration; the missing launch-error check lets the exchange
-// complete silently with the halo left untouched.
+// The unstructured GPU pack/unpack kernels used to place the number of index
+// blocks in gridDim.y, which CUDA limits to 65535. A halo with more indices
+// made the kernel launch fail with an invalid configuration; the missing
+// launch-error check let the exchange complete silently without touching the
+// halo.
 
 #include <gtest/gtest.h>
 #include "../mpi_runner/mpi_test_fixture.hpp"
@@ -41,15 +41,10 @@ using data_descriptor_gpu_type =
 
 namespace
 {
-// smallest halo for which the pack/unpack kernels exceed the CUDA gridDim.y
-// limit of 65535
-constexpr int halo_size = GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y * 65535 + 1;
-constexpr int inner_size = halo_size;
-
 // Each rank owns gids [rank*inner_size, (rank+1)*inner_size); its halo is the
 // first halo_size gids of the other rank, stored after the inner elements.
 domain_descriptor_type
-make_two_rank_domain(int rank)
+make_two_rank_domain(int rank, int inner_size, int halo_size)
 {
     const int                      other = 1 - rank;
     std::vector<global_index_type> gids(inner_size + halo_size);
@@ -59,6 +54,44 @@ make_two_rank_domain(int rank)
     std::iota(halo_lids.begin(), halo_lids.end(), inner_size);
     return {rank, gids.begin(), gids.end(), halo_lids.begin(), halo_lids.end()};
 }
+
+void
+run_exchange(ghex::context& ctxt, int halo_size, int levels)
+{
+    const int inner_size = halo_size;
+
+    std::vector<domain_descriptor_type> local_domains{
+        make_two_rank_domain(ctxt.rank(), inner_size, halo_size)};
+    const auto& d = local_domains[0];
+
+    std::set<global_index_type> halo_set(d.outer_gids().begin(), d.outer_gids().end());
+    halo_generator_type         hg{halo_set.begin(), halo_set.end()};
+
+    auto patterns = ghex::make_pattern<grid_type>(ctxt, hg, local_domains);
+    auto co = ghex::make_communication_object<decltype(patterns)>(ctxt);
+
+    const auto value = [&](unsigned int lid, int level)
+    { return static_cast<int>(d.global_index(lid).value()) * 100 + level + 1; };
+
+    ghex::test::util::memory<int> field(d.size() * levels, 0);
+    for (unsigned int lid = 0; lid < d.size(); ++lid)
+        for (int level = 0; level < levels; ++level)
+            field[lid * levels + level] =
+                lid < static_cast<unsigned int>(inner_size) ? value(lid, level) : 0;
+    field.clone_to_device();
+    data_descriptor_gpu_type data{d, field.device_data(), static_cast<std::size_t>(levels), true, 0,
+        0};
+
+    co.exchange(patterns(data)).wait();
+
+    field.clone_to_host();
+    int num_bad = 0;
+    for (unsigned int lid = inner_size; lid < d.size(); ++lid)
+        for (int level = 0; level < levels; ++level)
+            if (field[lid * levels + level] != value(lid, level)) ++num_bad;
+    EXPECT_EQ(num_bad, 0) << "halo elements were not exchanged correctly (halo_size=" << halo_size
+                          << ", levels=" << levels << ")";
+}
 } // namespace
 
 TEST_F(mpi_test_fixture, large_halo)
@@ -67,28 +100,12 @@ TEST_F(mpi_test_fixture, large_halo)
 
     ghex::context ctxt{MPI_COMM_WORLD, false};
 
-    std::vector<domain_descriptor_type> local_domains{make_two_rank_domain(ctxt.rank())};
-    const auto&                         d = local_domains[0];
+    // smallest halo for which more index blocks are needed than the CUDA
+    // gridDim limit of 65535 the kernels used to run into
+    run_exchange(ctxt, GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y * 65535 + 1, 1);
 
-    std::set<global_index_type> halo_set(d.outer_gids().begin(), d.outer_gids().end());
-    halo_generator_type         hg{halo_set.begin(), halo_set.end()};
-
-    auto patterns = ghex::make_pattern<grid_type>(ctxt, hg, local_domains);
-    auto co = ghex::make_communication_object<decltype(patterns)>(ctxt);
-
-    ghex::test::util::memory<int> field(d.size(), 0);
-    for (unsigned int lid = 0; lid < d.size(); ++lid)
-        field[lid] = lid < inner_size ? static_cast<int>(d.global_index(lid).value()) + 1 : 0;
-    field.clone_to_device();
-    data_descriptor_gpu_type data{d, field.device_data(), 1, true, 0, 0};
-
-    co.exchange(patterns(data)).wait();
-
-    field.clone_to_host();
-    int num_bad = 0;
-    for (unsigned int lid = inner_size; lid < d.size(); ++lid)
-        if (field[lid] != static_cast<int>(d.global_index(lid).value()) + 1) ++num_bad;
-    EXPECT_EQ(num_bad, 0) << "halo elements were not exchanged correctly";
+    // more levels than fit in one block in the levels dimension
+    run_exchange(ctxt, 1000, 2 * GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_X);
 }
 
 #else // GHEX_CUDACC

--- a/test/unstructured/test_large_halo.cpp
+++ b/test/unstructured/test_large_halo.cpp
@@ -41,8 +41,9 @@ using data_descriptor_gpu_type =
 
 namespace
 {
-// larger than GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y * 65535
-constexpr int halo_size = 600000;
+// smallest halo for which the pack/unpack kernels exceed the CUDA gridDim.y
+// limit of 65535
+constexpr int halo_size = GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y * 65535 + 1;
 constexpr int inner_size = halo_size;
 
 // Each rank owns gids [rank*inner_size, (rank+1)*inner_size); its halo is the


### PR DESCRIPTION
The unstructured GPU pack/unpack kernels (`unstructured/user_concepts.hpp`) put `ceil(num_indices / blockDim.y)` into `gridDim.y`, which CUDA limits to 65535. With the current block size (`GHEX_UNSTRUCTURED_SERIALIZATION_THREADS_PER_BLOCK_Y = 8`), any halo with more than 8 * 65535 = 524280 indices per neighbour makes the kernel launch fail with an invalid configuration. Since the launch error is never checked, the exchange completes without any error and the halo is simply left untouched.

Observed on santis (GH200): a 2-rank unstructured exchange with 1048576 halo indices per rank leaves the entire halo at its pre-exchange values, on both the send side (pack) and the receive side (unpack), for both cray-mpich 8.x and 9.x — the bug is in the kernel launch, not the transport.

This PR adds a failing test (`test/unstructured/test_large_halo.cpp`, runs as `parallel-ranks-2` on the GPU CI): a quiescent 2-rank exchange with 600000 halo indices per neighbour, verifying the halo contents afterwards. CI is expected to be red on the GPU pipelines.

The fix is now included: the levels-first kernels map the index blocks to gridDim.x (limit 2^31-1) instead of gridDim.y, keeping the thread mapping — and thus memory coalescing — unchanged, and all four pack/unpack launches are followed by a launch-error check so an invalid configuration can never pass silently again. The test additionally covers more levels than fit in one block (exercising the level-block grid dimension) and derives the overflowing halo size from the block-size macro. Validated on santis: the test is green after the fix, and the repeated-exchange hang described above no longer occurs. The red state is preserved in the CI runs of the earlier, test-only pushes.

---

Update: the failure mode is worse than silent corruption. In a loop of repeated exchanges with an oversized halo, the first exchange completes (with the halo untouched) and a subsequent exchange hangs until the job time limit (observed on santis with both cray-mpich 8.x and 9.x, intra- and inter-node). The single-exchange test in this PR does not hang, it fails the content check.

