### PR TITLE
GPU unpack from inline receive completion races with pre-exchange kernels on the user stream

### DIFF
--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -95,7 +95,7 @@ build_libfabric:
   extends: .container-runner-clariden-gh200
   variables:
     SLURM_GPUS_PER_TASK: 1
-    SLURM_TIMELIMIT: '5:00'
+    SLURM_TIMELIMIT: '10:00'
     SLURM_PARTITION: normal
     SLURM_MPI_TYPE: pmix
     SLURM_NETWORK: disable_rdzv_get
@@ -121,7 +121,7 @@ build_libfabric:
     # writing inside the container.
     - if [[ "${SLURM_LOCALID}" == 0 ]]; then rm -rf /ghex/build/Testing; mkdir /tmp/Testing; ln -s /tmp/Testing /ghex/build/Testing; fi
     - until [[ -L /ghex/build/Testing ]]; do sleep 1; done
-    - spack -e ci build-env ghex -- ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 60
+    - spack -e ci build-env ghex -- ctest --test-dir /ghex/build -L "parallel-ranks-${SLURM_NTASKS}" --output-on-failure --timeout 180
 
 .test_parallel_job:
   extends: .test_parallel_template
@@ -185,6 +185,12 @@ test_parallel_2_mpi:
   variables:
     SLURM_NTASKS: 2
 
+test_parallel_2_mpi_2nodes:
+  extends: .test_parallel_mpi
+  variables:
+    SLURM_NTASKS: 2
+    SLURM_NTASKS_PER_NODE: 1
+
 test_parallel_4_mpi:
   extends: .test_parallel_mpi
   variables:
@@ -206,6 +212,12 @@ test_parallel_2_ucx:
   extends: .test_parallel_ucx
   variables:
     SLURM_NTASKS: 2
+
+test_parallel_2_ucx_2nodes:
+  extends: .test_parallel_ucx
+  variables:
+    SLURM_NTASKS: 2
+    SLURM_NTASKS_PER_NODE: 1
 
 test_parallel_4_ucx:
   extends: .test_parallel_ucx

--- a/.cscs-ci/default.yaml
+++ b/.cscs-ci/default.yaml
@@ -163,10 +163,22 @@ test_parallel_2_nccl:
   variables:
     SLURM_NTASKS: 2
 
+test_parallel_2_nccl_2nodes:
+  extends: .test_parallel_nccl
+  variables:
+    SLURM_NTASKS: 2
+    SLURM_NTASKS_PER_NODE: 1
+
 test_parallel_4_nccl:
   extends: .test_parallel_nccl
   variables:
     SLURM_NTASKS: 4
+
+test_parallel_4_nccl_4nodes:
+  extends: .test_parallel_nccl
+  variables:
+    SLURM_NTASKS: 4
+    SLURM_NTASKS_PER_NODE: 1
 
 test_parallel_6_nccl:
   extends: .test_parallel_nccl
@@ -196,6 +208,12 @@ test_parallel_4_mpi:
   variables:
     SLURM_NTASKS: 4
 
+test_parallel_4_mpi_4nodes:
+  extends: .test_parallel_mpi
+  variables:
+    SLURM_NTASKS: 4
+    SLURM_NTASKS_PER_NODE: 1
+
 test_parallel_6_mpi:
   extends: .test_parallel_mpi
   variables:
@@ -223,6 +241,12 @@ test_parallel_4_ucx:
   extends: .test_parallel_ucx
   variables:
     SLURM_NTASKS: 4
+
+test_parallel_4_ucx_4nodes:
+  extends: .test_parallel_ucx
+  variables:
+    SLURM_NTASKS: 4
+    SLURM_NTASKS_PER_NODE: 1
 
 test_parallel_6_ucx:
   extends: .test_parallel_ucx

--- a/test/unstructured/CMakeLists.txt
+++ b/test/unstructured/CMakeLists.txt
@@ -3,3 +3,6 @@ ghex_compile_test(user_concepts)
 ghex_reg_parallel_test(user_concepts 4 false)
 ghex_reg_parallel_test(user_concepts 2 true)
 
+ghex_compile_test(inline_unpack_race)
+ghex_reg_parallel_test(inline_unpack_race 2 false)
+

--- a/test/unstructured/test_inline_unpack_race.cpp
+++ b/test/unstructured/test_inline_unpack_race.cpp
@@ -256,18 +256,20 @@ TEST_F(mpi_test_fixture, inline_unpack_race)
     if (world_size != 2) GTEST_SKIP() << "test requires exactly 2 ranks";
 
     case_params p;
-    p.num_passes = static_cast<int>(env_or("RACE_PASSES", 4000));
-    p.spin_cycles = env_or("RACE_SPIN_CYCLES", 500000);
-    p.sleep_ms = env_or("RACE_SLEEP_MS", 150);
-    p.num_control_trials = static_cast<int>(env_or("RACE_CONTROL_TRIALS", 2));
-    p.num_trials = static_cast<int>(env_or("RACE_TRIALS", 8));
+    p.num_passes = static_cast<int>(env_or("GHEX_TEST_INLINE_UNPACK_RACE_PASSES", 5000));
+    p.spin_cycles = env_or("GHEX_TEST_INLINE_UNPACK_RACE_SPIN_CYCLES", 500000);
+    p.sleep_ms = env_or("GHEX_TEST_INLINE_UNPACK_RACE_SLEEP_MS", 150);
+    p.num_control_trials =
+        static_cast<int>(env_or("GHEX_TEST_INLINE_UNPACK_RACE_CONTROL_TRIALS", 2));
+    p.num_trials = static_cast<int>(env_or("GHEX_TEST_INLINE_UNPACK_RACE_TRIALS", 12));
 
     ghex::context ctxt{MPI_COMM_WORLD, false};
 
     // whether the inline completion fires depends on transport, message size and
     // placement; cover several eager-sized messages unless RACE_HALO selects one
-    std::vector<int> halo_sizes = {128, 512, 4096};
-    if (const long h = env_or("RACE_HALO", 0)) halo_sizes = {static_cast<int>(h)};
+    std::vector<int> halo_sizes = {128, 512, 4096, 8192};
+    if (const long h = env_or("GHEX_TEST_INLINE_UNPACK_RACE_HALO", 0))
+        halo_sizes = {static_cast<int>(h)};
 
     int total_overlap = 0;
     for (const int halo_size : halo_sizes)

--- a/test/unstructured/test_inline_unpack_race.cpp
+++ b/test/unstructured/test_inline_unpack_race.cpp
@@ -1,0 +1,289 @@
+/*
+ * ghex-org
+ *
+ * Copyright (c) 2014-2026, ETH Zurich
+ * All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Reproducer for a suspected race: when the transport completes a GPU receive
+// at Irecv-post time (oomph mpi backend, inline callback), the unpack kernel is
+// launched on a non-blocking stream while kernels submitted to the user stream
+// before schedule_exchange() may still be running and reading the halo.
+//
+// Rank 1 launches a long-running kernel on the user stream that repeatedly sums
+// the halo, then delays so that rank 0's (small, eager) message has already
+// arrived when it posts its receives. If unpacking respects the user stream, no
+// sum may contain post-exchange values.
+
+#include <gtest/gtest.h>
+#include "../mpi_runner/mpi_test_fixture.hpp"
+
+#include <ghex/config.hpp>
+#include <ghex/unstructured/pattern.hpp>
+#include <ghex/unstructured/user_concepts.hpp>
+#include <ghex/communication_object.hpp>
+#include "../util/memory.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+using domain_id_type = int;
+using global_index_type = int;
+using domain_descriptor_type =
+    ghex::unstructured::domain_descriptor<domain_id_type, global_index_type>;
+using halo_generator_type = ghex::unstructured::halo_generator<domain_id_type, global_index_type>;
+using grid_type = ghex::unstructured::grid;
+
+#ifdef GHEX_CUDACC
+
+#include <ghex/device/cuda/runtime.hpp>
+
+using data_descriptor_gpu_type =
+    ghex::unstructured::data_descriptor<ghex::gpu, domain_id_type, global_index_type, int>;
+
+namespace
+{
+long
+env_or(const char* name, long def)
+{
+    const char* v = std::getenv(name);
+    return v ? std::atol(v) : def;
+}
+
+// Each rank owns gids [rank*inner_size, (rank+1)*inner_size); its halo is the
+// first halo_size gids of the other rank, stored after the inner elements.
+domain_descriptor_type
+make_two_rank_domain(int rank, int inner_size, int halo_size)
+{
+    const int                      other = 1 - rank;
+    std::vector<global_index_type> gids(inner_size + halo_size);
+    std::iota(gids.begin(), gids.begin() + inner_size, rank * inner_size);
+    std::iota(gids.begin() + inner_size, gids.end(), other * inner_size);
+    std::vector<domain_descriptor_type::local_index_type> halo_lids(halo_size);
+    std::iota(halo_lids.begin(), halo_lids.end(), inner_size);
+    return {rank, gids.begin(), gids.end(), halo_lids.begin(), halo_lids.end()};
+}
+
+__global__ void
+reader_kernel(const int* field, int offset, int n, long long spin_cycles, int num_passes,
+    unsigned long long* sums)
+{
+    for (int p = 0; p < num_passes; ++p)
+    {
+        unsigned long long s = 0;
+        for (int i = 0; i < n; ++i) s += static_cast<const volatile int*>(field)[offset + i];
+        sums[p] = s;
+        const long long start = clock64();
+        while (clock64() - start < spin_cycles) {}
+    }
+}
+
+struct pass_stats
+{
+    int old_passes = 0;
+    int new_passes = 0;
+    int torn_passes = 0;
+    int first_overlap = -1;
+};
+
+pass_stats
+analyze(const unsigned long long* sums, int num_passes, unsigned long long expected_new)
+{
+    pass_stats st;
+    for (int p = 0; p < num_passes; ++p)
+    {
+        if (sums[p] == 0ull) ++st.old_passes;
+        else
+        {
+            if (st.first_overlap < 0) st.first_overlap = p;
+            if (sums[p] == expected_new) ++st.new_passes;
+            else
+                ++st.torn_passes;
+        }
+    }
+    return st;
+}
+
+struct case_params
+{
+    int  halo_size;
+    int  num_passes;
+    long spin_cycles;
+    long sleep_ms;
+    int  num_control_trials;
+    int  num_trials;
+};
+
+// returns the number of skewed trials in which the unpack overlapped the
+// pre-exchange reader kernel (only meaningful on rank 1)
+int
+run_case(ghex::context& ctxt, MPI_Comm world, const case_params& p)
+{
+    const int halo_size = p.halo_size;
+    const int inner_size = std::max(4096, halo_size);
+
+    std::vector<domain_descriptor_type> local_domains{
+        make_two_rank_domain(ctxt.rank(), inner_size, halo_size)};
+    const auto& d = local_domains[0];
+
+    std::set<global_index_type> halo_set(d.outer_gids().begin(), d.outer_gids().end());
+    halo_generator_type         hg{halo_set.begin(), halo_set.end()};
+
+    auto patterns = ghex::make_pattern<grid_type>(ctxt, hg, local_domains);
+    auto co = ghex::make_communication_object<decltype(patterns)>(ctxt);
+
+    ghex::test::util::memory<int>                field(d.size(), 0);
+    ghex::test::util::memory<unsigned long long> sums(p.num_passes, 0);
+    data_descriptor_gpu_type                     data_gpu{d, field.device_data(), 1, true, 0, 0};
+
+    // inner element with gid g holds g+1; halo starts at 0, so after unpacking
+    // each halo element is nonzero
+    unsigned long long expected_new = 0;
+    for (int i = 0; i < halo_size; ++i) expected_new += (1 - ctxt.rank()) * inner_size + i + 1;
+
+    cudaStream_t stream;
+    GHEX_CHECK_CUDA_RESULT(cudaStreamCreate(&stream));
+
+    const bool slow_rank = (ctxt.rank() == 1);
+    int        trials_with_overlap = 0;
+    int        trials_with_torn = 0;
+
+    for (int mode = 0; mode < 2; ++mode)
+    {
+        const bool sync_before_exchange = (mode == 0);
+        const int  n_trials = sync_before_exchange ? p.num_control_trials : p.num_trials;
+        for (int trial = 0; trial < n_trials; ++trial)
+        {
+            for (unsigned int lid = 0; lid < d.size(); ++lid)
+                field[lid] = lid < static_cast<unsigned int>(inner_size)
+                                 ? static_cast<int>(d.global_index(lid).value()) + 1
+                                 : 0;
+            field.clone_to_device();
+            for (int i = 0; i < p.num_passes; ++i) sums[i] = 0xdeadbeefull;
+            sums.clone_to_device();
+            GHEX_CHECK_CUDA_RESULT(cudaDeviceSynchronize());
+            MPI_Barrier(world);
+
+            if (slow_rank)
+            {
+                reader_kernel<<<1, 1, 0, stream>>>(field.device_data(), inner_size, halo_size,
+                    p.spin_cycles, p.num_passes, sums.device_data());
+                GHEX_CHECK_CUDA_RESULT(cudaGetLastError());
+                if (sync_before_exchange) { GHEX_CHECK_CUDA_RESULT(cudaDeviceSynchronize()); }
+                else
+                {
+                    // progress MPI while waiting, like a busy application rank would,
+                    // so the neighbour's unexpected message gets staged before Irecv;
+                    // stagger the delay across trials to sample different
+                    // arrival/progress interleavings
+                    const long this_sleep_ms = p.sleep_ms + trial * 50;
+                    for (long t = 0; t < this_sleep_ms; ++t)
+                    {
+                        int flag;
+                        MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, world, &flag, MPI_STATUS_IGNORE);
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    }
+                }
+            }
+
+            auto h = co.schedule_exchange(stream, patterns(data_gpu));
+            h.schedule_wait(stream);
+            GHEX_CHECK_CUDA_RESULT(cudaStreamSynchronize(stream));
+
+            field.clone_to_host();
+            {
+                int first_bad = -1, num_bad = 0;
+                for (unsigned int lid = inner_size; lid < d.size(); ++lid)
+                    if (field[lid] != static_cast<int>(d.global_index(lid).value()) + 1)
+                    {
+                        if (first_bad < 0) first_bad = static_cast<int>(lid);
+                        ++num_bad;
+                    }
+                if (num_bad > 0)
+                    std::fprintf(stderr,
+                        "[rank %d] %s trial %2d: halo mismatches %d/%d, first at lid %d "
+                        "(value %d, expected %d)\n",
+                        ctxt.rank(), sync_before_exchange ? "control" : "race   ", trial, num_bad,
+                        halo_size, first_bad, field[first_bad],
+                        static_cast<int>(d.global_index(first_bad).value()) + 1);
+                EXPECT_EQ(num_bad, 0) << "halo content wrong";
+            }
+
+            if (slow_rank)
+            {
+                sums.clone_to_host();
+                const auto st = analyze(sums.host_data(), p.num_passes, expected_new);
+                std::fprintf(stderr,
+                    "[rank 1] %s trial %2d: passes old=%d new=%d torn=%d first_overlap=%d\n",
+                    sync_before_exchange ? "control" : "race   ", trial, st.old_passes,
+                    st.new_passes, st.torn_passes, st.first_overlap);
+                if (sync_before_exchange)
+                {
+                    EXPECT_EQ(st.new_passes + st.torn_passes, 0)
+                        << "control run must not observe post-exchange halo values";
+                }
+                else
+                {
+                    trials_with_overlap += (st.new_passes + st.torn_passes) > 0 ? 1 : 0;
+                    trials_with_torn += st.torn_passes > 0 ? 1 : 0;
+                }
+            }
+            MPI_Barrier(world);
+        }
+    }
+
+    if (slow_rank)
+        std::fprintf(stderr,
+            "[rank 1] summary (halo=%d ints, %zu bytes): %d/%d skewed trials with unpack "
+            "overlapping the pre-exchange kernel (%d with torn reads)\n",
+            halo_size, halo_size * sizeof(int), trials_with_overlap, p.num_trials,
+            trials_with_torn);
+
+    GHEX_CHECK_CUDA_RESULT(cudaStreamDestroy(stream));
+    return trials_with_overlap;
+}
+} // namespace
+
+TEST_F(mpi_test_fixture, inline_unpack_race)
+{
+    if (world_size != 2) GTEST_SKIP() << "test requires exactly 2 ranks";
+
+    case_params p;
+    p.num_passes = static_cast<int>(env_or("RACE_PASSES", 4000));
+    p.spin_cycles = env_or("RACE_SPIN_CYCLES", 500000);
+    p.sleep_ms = env_or("RACE_SLEEP_MS", 150);
+    p.num_control_trials = static_cast<int>(env_or("RACE_CONTROL_TRIALS", 2));
+    p.num_trials = static_cast<int>(env_or("RACE_TRIALS", 8));
+
+    ghex::context ctxt{MPI_COMM_WORLD, false};
+
+    // whether the inline completion fires depends on transport, message size and
+    // placement; cover several eager-sized messages unless RACE_HALO selects one
+    std::vector<int> halo_sizes = {128, 512, 4096};
+    if (const long h = env_or("RACE_HALO", 0)) halo_sizes = {static_cast<int>(h)};
+
+    int total_overlap = 0;
+    for (const int halo_size : halo_sizes)
+    {
+        p.halo_size = halo_size;
+        total_overlap += run_case(ctxt, world, p);
+    }
+
+    if (ctxt.rank() == 1)
+        EXPECT_EQ(total_overlap, 0)
+            << "unpack kernel ran concurrently with work submitted to the user stream before "
+               "schedule_exchange()";
+}
+
+#else // GHEX_CUDACC
+
+TEST_F(mpi_test_fixture, inline_unpack_race) { GTEST_SKIP() << "GPU-only test"; }
+
+#endif

--- a/test/unstructured/test_inline_unpack_race.cpp
+++ b/test/unstructured/test_inline_unpack_race.cpp
@@ -29,8 +29,10 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <numeric>
+#include <set>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
The oomph MPI backend completes receives inline when `MPI_Test` succeeds directly after `MPI_Irecv` (`src/mpi/communicator.hpp`). For GPU fields the completion callback launches the unpack kernel on the buffer's non-blocking stream. This happens inside `post_recvs()`, i.e. before `post_sends()` has drained the device, and nothing orders the unpack kernel after work submitted to the user stream before `schedule_exchange()`. Kernels still running on the user stream can therefore read halo elements while the unpack overwrites them. The deferred-callback path is safe only incidentally: `post_sends()` host-blocks on pack kernels which wait on the user-stream event recorded in `schedule_sync_pack()`.

This was originally observed as sporadic verification failures in ICON + ICON4Py on Alps after a cray-mpich upgrade; the exchanged field itself always ends up correct, only consumers of the halo that were already running are affected — which made it look like a compiler/codegen bug for a long time.

The test creates rank imbalance (rank 1 runs a long halo-reading kernel on the user stream and delays posting its receives while progressing MPI) so that the neighbour's small message has already arrived at `MPI_Irecv` time. Per-pass halo checksums in the reading kernel detect any unpack overlap.

Measured on santis (GH200, 2 ranks on 2 nodes): which message size fires varies from run to run (likely with node placement), so each invocation covers four eager-sized messages (512 B, 2 KB, 16 KB, 32 KB) with 12 skewed trials per size and the skew staggered across trials. With these default settings and cray-mpich 9.1.0, 5 out of 5 test invocations failed without the fix — notably via a different message size each time — and 5 out of 5 passed with it (torn halo reads were observed twice across the campaign). With cray-mpich 8.x the branch fires less often but overlap was still observed in every full sweep. Intra-node the branch never fired on either version. One invocation takes ~85 s, hence the ctest timeout increase for parallel tests (which recently also hit spurious timeouts elsewhere). Deferring all callbacks (forcing the else-branch in oomph) eliminates the overlap completely. Whether the CI transport (external OpenMPI 5.0.10) completes receives at post time is exactly what this PR should reveal — hence the new 2-node CI jobs; the single-node jobs are not expected to trigger it.

Note the test is expected to be red *probabilistically* on affected transports. A fix (ordering the unpack streams after the user stream before `post_recvs()`) follows in a separate PR, which makes the test deterministically green.

Env knobs for manual investigation: `GHEX_TEST_INLINE_UNPACK_RACE_HALO` (ints per halo), `..._PASSES`, `..._SPIN_CYCLES`, `..._SLEEP_MS`, `..._CONTROL_TRIALS`, `..._TRIALS`.


