### PR TITLE
Fix two gaps in the python test setup: leaked cart communicator, missing cupy

### DIFF
--- a/test/bindings/python/CMakeLists.txt
+++ b/test/bindings/python/CMakeLists.txt
@@ -5,6 +5,14 @@
 set(venv_dir "${CMAKE_BINARY_DIR}/test_venv")
 # test requirements
 set(reqs "${CMAKE_SOURCE_DIR}/bindings/python/min-requirements-test.txt")
+# the gpu parametrizations of the python tests skip unless cupy is importable
+if (ghex_gpu_mode STREQUAL "cuda")
+    if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13)
+        set(gpu_reqs "cupy-cuda12x")
+    else()
+        set(gpu_reqs "cupy-cuda13x")
+    endif()
+endif()
 # get the path to the pyghex module's parent directory
 get_target_property(python_mod_path pyghex LIBRARY_OUTPUT_DIRECTORY)
 get_filename_component(pyghex_test_workdir ${python_mod_path}/.. ABSOLUTE)
@@ -32,7 +40,7 @@ add_custom_command(
 # command to install test dependencies into the virtual environment
 add_custom_command(
     OUTPUT ${venv_dir}/bin/pytest
-    COMMAND ${venv_dir}/bin/pip install -r ${reqs}
+    COMMAND ${venv_dir}/bin/pip install -r ${reqs} ${gpu_reqs}
     DEPENDS ${venv_dir}/bin/pip-upgraded
     COMMENT "Installing test dependencies"
 )

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -49,86 +49,90 @@ def test_pattern(capsys, ndim, periodic):
     periodicity = tuple(periodic if d == 0 else True for d in range(ndim))
 
     mpi_cart_comm = mpi_comm.Create_cart(dims=dims, periods=list(periodicity))
+    try:
+        ctx = make_context(mpi_cart_comm, True)
 
-    ctx = make_context(mpi_cart_comm, True)
+        p_coord = tuple(mpi_cart_comm.Get_coords(mpi_cart_comm.Get_rank()))
+        global_grid = IndexSpace.from_sizes(*sizes[:ndim])
+        sub_grids = global_grid.decompose(mpi_cart_comm.dims)
+        owned_indices = sub_grids[p_coord].subset["definition"]  # sub-grid in global coordinates
+        sub_grid = IndexSpace(
+            {
+                "definition": owned_indices,
+                "halo": owned_indices.extend(*halos).without(owned_indices),
+            }
+        )
 
-    p_coord = tuple(mpi_cart_comm.Get_coords(mpi_cart_comm.Get_rank()))
-    global_grid = IndexSpace.from_sizes(*sizes[:ndim])
-    sub_grids = global_grid.decompose(mpi_cart_comm.dims)
-    owned_indices = sub_grids[p_coord].subset["definition"]  # sub-grid in global coordinates
-    sub_grid = IndexSpace(
-        {
-            "definition": owned_indices,
-            "halo": owned_indices.extend(*halos).without(owned_indices),
-        }
-    )
+        memory_local_grid = sub_grid.translate(
+            *(-origin_l for origin_l in sub_grid.bounds[(0,) * ndim])
+        )
 
-    memory_local_grid = sub_grid.translate(
-        *(-origin_l for origin_l in sub_grid.bounds[(0,) * ndim])
-    )
+        domain_desc = DomainDescriptor(ctx.rank(), owned_indices)
+        halo_gen = HaloGenerator(global_grid.subset["definition"], halos, periodicity)
 
-    domain_desc = DomainDescriptor(ctx.rank(), owned_indices)
-    halo_gen = HaloGenerator(global_grid.subset["definition"], halos, periodicity)
+        pattern = make_pattern(ctx, halo_gen, [domain_desc])
 
-    pattern = make_pattern(ctx, halo_gen, [domain_desc])
+        with capsys.disabled():
+            print("python side: making co")
+            print(pattern.grid_type)
+            print(pattern.domain_id_type)
 
-    with capsys.disabled():
-        print("python side: making co")
-        print(pattern.grid_type)
-        print(pattern.domain_id_type)
+        co = make_communication_object(ctx)
 
-    co = make_communication_object(ctx)
+        def make_field():
+            field_1 = np.zeros(
+                memory_local_grid.bounds.shape, dtype=np.float64, order="F"
+            )  # todo: , order='F'
+            # field_1 = cp.zeros(memory_local_grid.bounds.shape, dtype=np.float64, order='F')
+            gfield_1 = make_field_descriptor(
+                domain_desc,
+                field_1,
+                memory_local_grid.subset["definition"][(0,) * ndim],
+                memory_local_grid.bounds.shape,
+            )  # ,
+            # arch=architecture.CPU)
+            return field_1, gfield_1
 
-    def make_field():
-        field_1 = np.zeros(
-            memory_local_grid.bounds.shape, dtype=np.float64, order="F"
-        )  # todo: , order='F'
-        # field_1 = cp.zeros(memory_local_grid.bounds.shape, dtype=np.float64, order='F')
-        gfield_1 = make_field_descriptor(
-            domain_desc,
-            field_1,
-            memory_local_grid.subset["definition"][(0,) * ndim],
-            memory_local_grid.bounds.shape,
-        )  # ,
-        # arch=architecture.CPU)
-        return field_1, gfield_1
+        # one field per dimension, each storing the owner's coordinate in that dimension
+        fields = []
+        gfields = []
+        for _ in range(ndim):
+            field, gfield = make_field()
+            fields.append(field)
+            gfields.append(gfield)
+        for p_dim, p_coord_l in enumerate(p_coord):
+            fields[p_dim][...] = p_coord_l
 
-    # one field per dimension, each storing the owner's coordinate in that dimension
-    fields = []
-    gfields = []
-    for _ in range(ndim):
-        field, gfield = make_field()
-        fields.append(field)
-        gfields.append(gfield)
-    for p_dim, p_coord_l in enumerate(p_coord):
-        fields[p_dim][...] = p_coord_l
+        res = co.exchange([pattern(gfield) for gfield in gfields])
+        res.wait()
 
-    res = co.exchange([pattern(gfield) for gfield in gfields])
-    res.wait()
+        rank_field, grank_field = make_field()
+        rank_field[...] = ctx.rank()
+        # cp.cuda.Device(0).synchronize()
+        res = co.exchange(
+            [pattern(grank_field)]
+        )  # arch, dtype. exchange of fields living on cpu+gpu possible
+        res.wait()
+        # cp.cuda.Device(0).synchronize()
 
-    rank_field, grank_field = make_field()
-    rank_field[...] = ctx.rank()
-    # cp.cuda.Device(0).synchronize()
-    res = co.exchange(
-        [pattern(grank_field)]
-    )  # arch, dtype. exchange of fields living on cpu+gpu possible
-    res.wait()
-    # cp.cuda.Device(0).synchronize()
+        with capsys.disabled():
+            print("post_ex:")
+            print(rank_field)
 
-    with capsys.disabled():
-        print("post_ex:")
-        print(rank_field)
+        last = global_grid.subset["definition"][(-1,) * ndim]
+        for m_idx, local_idx in zip(memory_local_grid.bounds, sub_grid.bounds):
+            value_owner_coord = tuple(int(fields[dim][m_idx]) for dim in range(ndim))
+            value_owner_rank = mpi_cart_comm.Get_cart_rank(value_owner_coord)
+            if all(l >= 0 and l <= last[d] for d, l in enumerate(local_idx)):
+                assert local_idx in sub_grids[value_owner_coord].subset["definition"]
 
-    last = global_grid.subset["definition"][(-1,) * ndim]
-    for m_idx, local_idx in zip(memory_local_grid.bounds, sub_grid.bounds):
-        value_owner_coord = tuple(int(fields[dim][m_idx]) for dim in range(ndim))
-        value_owner_rank = mpi_cart_comm.Get_cart_rank(value_owner_coord)
-        if all(l >= 0 and l <= last[d] for d, l in enumerate(local_idx)):
-            assert local_idx in sub_grids[value_owner_coord].subset["definition"]
+                assert rank_field[m_idx] == value_owner_rank
 
-            assert rank_field[m_idx] == value_owner_rank
-
-    # Without this every parametrization leaks an MPI context id and leaves UCX state
-    # behind, which makes later parallel tests hang. No teardown ordering is needed:
-    # the ghex context holds a duplicate of this communicator, not the communicator.
-    mpi_cart_comm.Free()
+    finally:
+        # Without this every parametrization leaks an MPI context id and leaves UCX
+        # state behind, which makes later parallel tests hang. Freeing in `finally`
+        # ensures a rank that fails an assertion still takes part in the collective
+        # Free, instead of leaving the passing ranks blocked in it. No teardown
+        # ordering is needed: the ghex context holds a duplicate of this
+        # communicator, not the communicator itself.
+        mpi_cart_comm.Free()

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -7,6 +7,8 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 #
+import gc
+
 import numpy as np
 import pytest
 
@@ -127,3 +129,10 @@ def test_pattern(capsys, ndim, periodic):
             assert local_idx in sub_grids[value_owner_coord].subset["definition"]
 
             assert rank_field[m_idx] == value_owner_rank
+
+    # Same cleanup the `cart_context`/`mpi_cart_comm` fixtures do: without it every
+    # parametrization leaks an MPI context id and leaves UCX state behind, which makes
+    # later parallel tests hang.
+    del ctx
+    gc.collect()
+    mpi_cart_comm.Free()

--- a/test/bindings/python/test_structured_pattern.py
+++ b/test/bindings/python/test_structured_pattern.py
@@ -7,8 +7,6 @@
 # Please, refer to the LICENSE file in the root directory.
 # SPDX-License-Identifier: BSD-3-Clause
 #
-import gc
-
 import numpy as np
 import pytest
 
@@ -130,9 +128,7 @@ def test_pattern(capsys, ndim, periodic):
 
             assert rank_field[m_idx] == value_owner_rank
 
-    # Same cleanup the `cart_context`/`mpi_cart_comm` fixtures do: without it every
-    # parametrization leaks an MPI context id and leaves UCX state behind, which makes
-    # later parallel tests hang.
-    del ctx
-    gc.collect()
+    # Without this every parametrization leaks an MPI context id and leaves UCX state
+    # behind, which makes later parallel tests hang. No teardown ordering is needed:
+    # the ghex context holds a duplicate of this communicator, not the communicator.
     mpi_cart_comm.Free()

--- a/test/bindings/python/test_unstructured_domain_descriptor.py
+++ b/test/bindings/python/test_unstructured_domain_descriptor.py
@@ -344,8 +344,11 @@ def test_domain_descriptor_async(on_gpu, stream_type, capsys, mpi_cart_comm, car
         inner_set = set(domains[ctx.rank()]["inner"])
         all_list = domains[ctx.rank()]["all"]
         if on_gpu:
+            # cupy does not understand the `__cuda_stream__` protocol, so pass the
+            # mock's underlying cupy stream for the device-to-host copy
+            cupy_stream = getattr(stream, "cupy_stream", stream)
             # NOTE: Without the explicit order it fails sometimes.
-            data = cp.asnumpy(data, order=order, stream=stream, blocking=True)
+            data = cp.asnumpy(data, order=order, stream=cupy_stream, blocking=True)
 
         for x in range(len(all_list)):
             gid = all_list[x]


### PR DESCRIPTION
Two independent fixes to the python test setup, from reviewing #221.

**Free the cartesian communicator in `test_structured_pattern`.** `test_pattern` builds its own cartesian communicator rather than using the `mpi_cart_comm` fixture, and never frees it. The fixture in `fixtures/context.py` does free its communicator, with the note that not doing so makes subsequent parallel tests hang with the UCX backend — this test bypasses that. Each `Create_cart` also consumes an MPI context id (as does the `MPI_Comm_dup` that `oomph::util::mpi_comm_holder` performs when the context is built), and the MPICH family, Cray MPICH included, has a hard cap on those.

Freeing is safe here: `MPI_Comm_free` is collective and all ranks take the same path through this test (no rank-dependent skips), and the GHEX context does not alias the communicator — `mpi_comm_holder` duplicates it on construction and frees the duplicate in its destructor — so the free needs no ordering against the context teardown. The cleanup does not run if an assertion fails earlier, but the ranks have already diverged at that point.

**Install cupy into the test venv for cuda builds.** Every `gpu=True` parametrization of the python tests skips on `import cupy` failing, and the venv is created without `--system-site-packages`. The CSCS GH200 runners are the only place the python tests meet a GPU, so today none of the GPU python paths — `Architecture.GPU` field descriptors, `schedule_exchange`, `schedule_wait`, `has_scheduled_exchange`, all three branches of `extract_cuda_stream` — are covered anywhere.

Trade-offs worth a second opinion:
- The GitHub `gpu-cuda` job builds with `GHEX_USE_GPU=ON` but has no GPU, so it pays the wheel download and still skips. If that matters the condition could be narrowed.
- The wheel is picked from `CMAKE_CUDA_COMPILER_VERSION` (`cupy-cuda12x` / `cupy-cuda13x`). HIP is left alone: cupy's rocm wheels are pinned to specific rocm versions and there is no runner to validate a choice against.

Separately, and not fixed here: `test_structured_pattern` is registered at 8 ranks and the CSCS pipeline only defines jobs for 2, 4 and 6, so that test never runs on GPU hardware regardless of cupy.

