### PR TITLE
Register has_scheduled_exchange once per communication object

### DIFF
--- a/bindings/python/src/_pyghex/unstructured/communication_object.cpp
+++ b/bindings/python/src/_pyghex/unstructured/communication_object.cpp
@@ -107,7 +107,7 @@ register_communication_object(nanobind::module_& m)
 
 #if defined(GHEX_CUDACC)
             _communication_object.def("has_scheduled_exchange",
-                [](type& co) -> bool { return co.has_scheduled_exchange(); });
+                [](const type& co) -> bool { return co.has_scheduled_exchange(); });
 #endif
 
             _handle

--- a/bindings/python/src/_pyghex/unstructured/communication_object.cpp
+++ b/bindings/python/src/_pyghex/unstructured/communication_object.cpp
@@ -105,6 +105,11 @@ register_communication_object(nanobind::module_& m)
             auto _communication_object = register_class<type>(m);
             auto _handle = register_class<handle>(m);
 
+#if defined(GHEX_CUDACC)
+            _communication_object.def("has_scheduled_exchange",
+                [](type& co) -> bool { return co.has_scheduled_exchange(); });
+#endif
+
             _handle
                 .def("wait", &handle::wait)
 #if defined(GHEX_CUDACC)
@@ -174,8 +179,6 @@ register_communication_object(nanobind::module_& m)
                             },
                             nanobind::keep_alive<0, 1>(), nanobind::arg("stream").none(),
                             nanobind::arg("b0"), nanobind::arg("b1"), nanobind::arg("b2"))
-                        .def("has_scheduled_exchange",
-                            [](type& co) -> bool { return co.has_scheduled_exchange(); })
 #endif // end scheduled exchange
                         ;
                 });


### PR DESCRIPTION
`has_scheduled_exchange` is `.def`'d on `_communication_object` from inside the `for_each` over `field_descriptor_specializations`, but unlike the `exchange`/`schedule_exchange` bindings next to it, its lambda signature (`[](type&) -> bool`) does not depend on `buffer_info_type`. The identical overload is therefore registered once per field specialization — `types::data` (5) x `types::archs` (2) = ten times per communication-object specialization — and every registration after the first is unreachable.

No behaviour change; it removes dead overloads from the module-init path.

Found while reviewing #221, which adds the same binding to the structured bindings (with a much larger multiplier there, since the structured `_communication_object` is a single class registered outside both loops).
